### PR TITLE
Fks

### DIFF
--- a/src/ManageCourses.Domain/DatabaseAccess/IManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/IManageCoursesDbContext.cs
@@ -9,6 +9,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
         DbSet<ProviderMapper> ProviderMappers { get; set; }
         DbSet<Course> Courses { get; set; }
         DbSet<UcasCourse> UcasCourses { get; set; }
+        DbSet<CourseCode> CourseCodes { get; set; }
         DbSet<UcasInstitution> UcasInstitutions { get; set; }
         DbSet<UcasCourseSubject> UcasCourseSubjects { get; set; }
         DbSet<UcasSubject> UcasSubjects { get; set; }

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
@@ -23,45 +22,89 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                 }
             }
 
-            // Fk from org-user join table to user
+            modelBuilder.Entity<McOrganisationUser>()
+                .HasIndex(ou => new { ou.Email, ou.OrgId })
+                .IsUnique();
             modelBuilder.Entity<McOrganisationUser>()
                 .HasOne(ou => ou.McUser)
                 .WithMany(u => u.McOrganisationUsers)
                 .HasForeignKey(ou => ou.Email)
                 .HasPrincipalKey(u => u.Email);
-
-            // Fk from org-user join table to org
             modelBuilder.Entity<McOrganisationUser>()
                 .HasOne(ou => ou.McOrganisation)
                 .WithMany(u => u.McOrganisationUsers)
                 .HasForeignKey(ou => ou.OrgId)
                 .HasPrincipalKey(u => u.OrgId);
 
-            modelBuilder.Entity<McOrganisationUser>()
-                .HasIndex(ou => new { ou.Email, ou.OrgId })
-                .IsUnique();
-
-            modelBuilder.Entity<McOrganisationInstitution>()
-                .HasIndex(oi => new { oi.OrgId, oi.InstitutionCode })
-                .IsUnique();
-
             modelBuilder.Entity<UcasInstitution>()
                 .HasIndex(ui => ui.InstCode)
                 .IsUnique();
 
-            // Fk from org-inst join table to org
-            modelBuilder.Entity<McOrganisationInstitution>()
-                .HasOne(ou => ou.McOrganisation)
-                .WithMany(u => u.McOrganisationInstitutions)
-                .HasForeignKey(ou => ou.OrgId)
-                .HasPrincipalKey(o => o.OrgId);
+            modelBuilder.Entity<UcasCampus>()
+                .HasOne(uc => uc.UcasInstitution)
+                .WithMany(ui => ui.UcasCampuses)
+                .HasForeignKey(uc => uc.InstCode)
+                .HasPrincipalKey(ui => ui.InstCode);
 
-            // Fk from org-inst join table to inst
             modelBuilder.Entity<McOrganisationInstitution>()
-                .HasOne(ou => ou.UcasInstitution)
-                .WithMany(i => i.McOrganisationInstitutions)
-                .HasForeignKey(ou => ou.InstitutionCode)
-                .HasPrincipalKey(u => u.InstCode);
+                .HasIndex(oi => new { oi.OrgId, oi.InstitutionCode })
+                .IsUnique();
+            modelBuilder.Entity<McOrganisationInstitution>()
+                .HasOne(oi => oi.McOrganisation)
+                .WithMany(o => o.McOrganisationInstitutions)
+                .HasForeignKey(oi => oi.OrgId)
+                .HasPrincipalKey(o => o.OrgId);
+            modelBuilder.Entity<McOrganisationInstitution>()
+                .HasOne(oi => oi.UcasInstitution)
+                .WithMany(ui => ui.McOrganisationInstitutions)
+                .HasForeignKey(oi => oi.InstitutionCode)
+                .HasPrincipalKey(ui => ui.InstCode);
+
+            modelBuilder.Entity<UcasCourse>()
+                .HasIndex(oi => new { oi.InstCode, oi.CrseCode, oi.CampusCode })
+                .IsUnique();
+            modelBuilder.Entity<UcasCourse>()
+                .HasOne(uc => uc.UcasInstitution)
+                .WithMany(ui => ui.UcasCourses)
+                .HasForeignKey(uc => uc.InstCode)
+                .HasPrincipalKey(ui => ui.InstCode);
+            modelBuilder.Entity<UcasCourse>()
+                .HasOne(uc => uc.CourseCode)
+                .WithMany(cc => cc.UcasCourses)
+                .HasForeignKey(uc => new { uc.InstCode, uc.CrseCode })
+                .HasPrincipalKey(cc => new { cc.InstCode, cc.CrseCode });
+            modelBuilder.Entity<UcasCourse>()
+                .HasOne(uc => uc.AccreditingProviderInstitution)
+                .WithMany(ui => ui.AccreditedUcasCourses)
+                .HasForeignKey(uc => uc.AccreditingProvider)
+                .HasPrincipalKey(ui => ui.InstCode);
+            modelBuilder.Entity<UcasCourse>()
+                .HasOne(uc => uc.UcasCampus)
+                .WithMany(ui => ui.UcasCourses)
+                .HasForeignKey(ucs => new { ucs.InstCode, ucs.CampusCode })
+                .HasPrincipalKey(ui => new { ui.InstCode, ui.CampusCode });
+
+            modelBuilder.Entity<CourseCode>()
+                .HasOne(cc => cc.UcasInstitution)
+                .WithMany(ui => ui.CourseCodes)
+                .HasForeignKey(oi => oi.InstCode)
+                .HasPrincipalKey(ui => ui.InstCode);
+
+            modelBuilder.Entity<UcasCourseSubject>()
+                .HasOne(ucs => ucs.UcasInstitution)
+                .WithMany(ui => ui.UcasCourseSubjects)
+                .HasForeignKey(ucs => ucs.InstCode)
+                .HasPrincipalKey(ui => ui.InstCode);
+            modelBuilder.Entity<UcasCourseSubject>()
+                .HasOne(ucs => ucs.UcasSubject)
+                .WithMany(us => us.UcasCourseSubjects)
+                .HasForeignKey(ucs => ucs.SubjectCode)
+                .HasPrincipalKey(ui => ui.SubjectCode);
+            modelBuilder.Entity<UcasCourseSubject>()
+                .HasOne(ucs => ucs.CourseCode)
+                .WithMany(cc => cc.UcasCourseSubjects)
+                .HasForeignKey(ucs => new { ucs.InstCode, ucs.CrseCode })
+                .HasPrincipalKey(cc => new { cc.InstCode, cc.CrseCode });
 
             base.OnModelCreating(modelBuilder);
         }
@@ -79,6 +122,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
 
         public DbSet<Course> Courses { get; set; }
         public DbSet<UcasCourse> UcasCourses { get; set; }
+        public DbSet<CourseCode> CourseCodes { get; set; }
         public DbSet<UcasInstitution> UcasInstitutions { get; set; }
         public DbSet<UcasCourseSubject> UcasCourseSubjects { get; set; }
         public DbSet<UcasSubject> UcasSubjects { get; set; }

--- a/src/ManageCourses.Domain/Migrations/20180706085148_Fks6.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180706085148_Fks6.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180706085148_Fks6")]
+    partial class Fks6
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20180706085148_Fks6.cs
+++ b/src/ManageCourses.Domain/Migrations/20180706085148_Fks6.cs
@@ -1,0 +1,239 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class Fks6 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "subject_code",
+                table: "ucas_subject",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "inst_code",
+                table: "ucas_campus",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "campus_code",
+                table: "ucas_campus",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldNullable: true);
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_ucas_subject_subject_code",
+                table: "ucas_subject",
+                column: "subject_code");
+
+            migrationBuilder.AddUniqueConstraint(
+                name: "AK_ucas_campus_inst_code_campus_code",
+                table: "ucas_campus",
+                columns: new[] { "inst_code", "campus_code" });
+
+            migrationBuilder.CreateTable(
+                name: "course_code",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
+                    crse_code = table.Column<string>(nullable: false),
+                    inst_code = table.Column<string>(nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_course_code", x => x.id);
+                    table.UniqueConstraint("AK_course_code_inst_code_crse_code", x => new { x.inst_code, x.crse_code });
+                    table.ForeignKey(
+                        name: "FK_course_code_ucas_institution_inst_code",
+                        column: x => x.inst_code,
+                        principalTable: "ucas_institution",
+                        principalColumn: "inst_code",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ucas_course_subject_subject_code",
+                table: "ucas_course_subject",
+                column: "subject_code");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ucas_course_subject_inst_code_crse_code",
+                table: "ucas_course_subject",
+                columns: new[] { "inst_code", "crse_code" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ucas_course_accrediting_provider",
+                table: "ucas_course",
+                column: "accrediting_provider");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ucas_course_inst_code_campus_code",
+                table: "ucas_course",
+                columns: new[] { "inst_code", "campus_code" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ucas_course_inst_code_crse_code_campus_code",
+                table: "ucas_course",
+                columns: new[] { "inst_code", "crse_code", "campus_code" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_campus_ucas_institution_inst_code",
+                table: "ucas_campus",
+                column: "inst_code",
+                principalTable: "ucas_institution",
+                principalColumn: "inst_code",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_ucas_institution_accrediting_provider",
+                table: "ucas_course",
+                column: "accrediting_provider",
+                principalTable: "ucas_institution",
+                principalColumn: "inst_code",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_ucas_institution_inst_code",
+                table: "ucas_course",
+                column: "inst_code",
+                principalTable: "ucas_institution",
+                principalColumn: "inst_code",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_ucas_campus_inst_code_campus_code",
+                table: "ucas_course",
+                columns: new[] { "inst_code", "campus_code" },
+                principalTable: "ucas_campus",
+                principalColumns: new[] { "inst_code", "campus_code" },
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_course_code_inst_code_crse_code",
+                table: "ucas_course",
+                columns: new[] { "inst_code", "crse_code" },
+                principalTable: "course_code",
+                principalColumns: new[] { "inst_code", "crse_code" },
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_subject_ucas_institution_inst_code",
+                table: "ucas_course_subject",
+                column: "inst_code",
+                principalTable: "ucas_institution",
+                principalColumn: "inst_code",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_subject_ucas_subject_subject_code",
+                table: "ucas_course_subject",
+                column: "subject_code",
+                principalTable: "ucas_subject",
+                principalColumn: "subject_code",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ucas_course_subject_course_code_inst_code_crse_code",
+                table: "ucas_course_subject",
+                columns: new[] { "inst_code", "crse_code" },
+                principalTable: "course_code",
+                principalColumns: new[] { "inst_code", "crse_code" },
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_campus_ucas_institution_inst_code",
+                table: "ucas_campus");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_ucas_institution_accrediting_provider",
+                table: "ucas_course");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_ucas_institution_inst_code",
+                table: "ucas_course");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_ucas_campus_inst_code_campus_code",
+                table: "ucas_course");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_course_code_inst_code_crse_code",
+                table: "ucas_course");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_subject_ucas_institution_inst_code",
+                table: "ucas_course_subject");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_subject_ucas_subject_subject_code",
+                table: "ucas_course_subject");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_ucas_course_subject_course_code_inst_code_crse_code",
+                table: "ucas_course_subject");
+
+            migrationBuilder.DropTable(
+                name: "course_code");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_ucas_subject_subject_code",
+                table: "ucas_subject");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ucas_course_subject_subject_code",
+                table: "ucas_course_subject");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ucas_course_subject_inst_code_crse_code",
+                table: "ucas_course_subject");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ucas_course_accrediting_provider",
+                table: "ucas_course");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ucas_course_inst_code_campus_code",
+                table: "ucas_course");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ucas_course_inst_code_crse_code_campus_code",
+                table: "ucas_course");
+
+            migrationBuilder.DropUniqueConstraint(
+                name: "AK_ucas_campus_inst_code_campus_code",
+                table: "ucas_campus");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "subject_code",
+                table: "ucas_subject",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "inst_code",
+                table: "ucas_campus",
+                nullable: true,
+                oldClrType: typeof(string));
+
+            migrationBuilder.AlterColumn<string>(
+                name: "campus_code",
+                table: "ucas_campus",
+                nullable: true,
+                oldClrType: typeof(string));
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/CourseCode.cs
+++ b/src/ManageCourses.Domain/Models/CourseCode.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Models
+{
+    /// <summary>
+    /// This is an implicit join table in the ucas source data.
+    /// The source data links from Ucas_Course_Subject to Course on
+    /// inst_code and crse_code but ucas_course is unique on campus as well.
+    /// This table holds the unique combinations of inst_code and crse_code
+    /// so that we can complete the chain of foreign keys
+    /// </summary>
+    public class CourseCode
+    {
+        public int Id { get; set; }
+        public string InstCode { get; set; }
+        public string CrseCode { get; set; }
+
+        public UcasInstitution UcasInstitution { get; set; }
+        public ICollection<UcasCourse> UcasCourses { get; set; }
+        public ICollection<UcasCourseSubject> UcasCourseSubjects { get; set; }
+    }
+}

--- a/src/ManageCourses.Domain/Models/UcasCampus.cs
+++ b/src/ManageCourses.Domain/Models/UcasCampus.cs
@@ -1,23 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations.Schema;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace GovUk.Education.ManageCourses.Domain.Models
 {
     public class UcasCampus
     {
         public int Id { get; set; }
-         public string InstCode { get; set; }
-         public string CampusCode { get; set; }
-         public string CampusName { get; set; }
-         public string Addr1 { get; set; }
-         public string Addr2 { get; set; }
-         public string Addr3 { get; set; }
-         public string Addr4 { get; set; }
-         public string Postcode { get; set; }
-         public string TelNo { get; set; }
-         public string Email { get; set; }
-         public string RegionCode { get; set; }
+        public string InstCode { get; set; }
+        public string CampusCode { get; set; }
+        public string CampusName { get; set; }
+        public string Addr1 { get; set; }
+        public string Addr2 { get; set; }
+        public string Addr3 { get; set; }
+        public string Addr4 { get; set; }
+        public string Postcode { get; set; }
+        public string TelNo { get; set; }
+        public string Email { get; set; }
+        public string RegionCode { get; set; }
+
+        public UcasInstitution UcasInstitution { get; set; }
+        public ICollection<UcasCourse> UcasCourses { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/UcasCourse.cs
+++ b/src/ManageCourses.Domain/Models/UcasCourse.cs
@@ -1,5 +1,3 @@
-using System.ComponentModel.DataAnnotations.Schema;
-
 namespace GovUk.Education.ManageCourses.Domain.Models
 {
     public class UcasCourse
@@ -15,5 +13,10 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string ProgramType { get; set; }
         public string AccreditingProvider { get; set; }
         public string CrseOpenDate { get; set; }
+
+        public UcasInstitution UcasInstitution { get; set; }
+        public UcasInstitution AccreditingProviderInstitution { get; set; }
+        public UcasCampus UcasCampus { get; set; }
+        public CourseCode CourseCode { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/UcasCourseSubject.cs
+++ b/src/ManageCourses.Domain/Models/UcasCourseSubject.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace GovUk.Education.ManageCourses.Domain.Models
+﻿namespace GovUk.Education.ManageCourses.Domain.Models
 {
     public class UcasCourseSubject
     {
@@ -11,5 +7,9 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string CrseCode { get; set; }
         public string SubjectCode { get; set; }
         public string YearCode { get; set; }
+
+        public UcasInstitution UcasInstitution { get; set; }
+        public CourseCode CourseCode { get; set; }
+        public UcasSubject UcasSubject { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/UcasInstitution.cs
+++ b/src/ManageCourses.Domain/Models/UcasInstitution.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace GovUk.Education.ManageCourses.Domain.Models
 {
@@ -25,5 +23,10 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string SchemeMember { get; set; }
 
         public ICollection<McOrganisationInstitution> McOrganisationInstitutions { get; set; }
+        public ICollection<UcasCourse> UcasCourses { get; set; }
+        public ICollection<UcasCourse> AccreditedUcasCourses { get; set; }
+        public ICollection<UcasCourseSubject> UcasCourseSubjects { get; set; }
+        public ICollection<UcasCampus> UcasCampuses { get; set; }
+        public ICollection<CourseCode> CourseCodes { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/UcasSubject.cs
+++ b/src/ManageCourses.Domain/Models/UcasSubject.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace GovUk.Education.ManageCourses.Domain.Models
 {
@@ -10,5 +8,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string SubjectCode { get; set; }
         public string SubjectDescription { get; set; }
         public string TitleMatch { get; set; }
+
+        public ICollection<UcasCourseSubject> UcasCourseSubjects { get; set; }
     }
 }


### PR DESCRIPTION
### Context

The disjointed data set is hard to follow, and the lack of fks makes tools like http://schemaexplorer.io/ much less useful for navigating around the data. While working this before it's also become clear that the dataset isn't internally consistent so adding fks should pull that problem forward to the import instead of blowing up on users down the line.

There's a matching PR for the importer https://github.com/DFE-Digital/manage-courses-ucas-importer/pull/21 that makes it skip anything that violates these new constraints.

### Changes proposed in this pull request

Add fks to the existing ucas tables, add a new table to jump the gap between course_subject and course (course is not distinct on inst_code+crse_code, but course_subject doesn't include the third key campus_code)

