### PR TITLE
Don't fall over when the user's email isn't known

### DIFF
--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -42,7 +42,12 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                 {
                     var userDetails = GetJsonUserDetails(accessToken);
 
-                    var mcuser = _manageCoursesDbContext.McUsers.First(x => x.Email == userDetails.Email);
+                    var mcuser = _manageCoursesDbContext.McUsers.FirstOrDefault(x => x.Email == userDetails.Email);
+                    if (mcuser == null)
+                    {
+                        Logger.LogWarning($"SignIn subject {userDetails.Subject} not found in McUsers data");
+                        return AuthenticateResult.NoResult();
+                    }
 
                     var identity = new ClaimsIdentity( 
                         new[] {
@@ -62,10 +67,8 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                     return AuthenticateResult.Fail(ex);
                 }
             }
-            else
-            {
-                return AuthenticateResult.NoResult();
-            }
+
+            return AuthenticateResult.NoResult();
         }
 
         private string GetAccessToken()


### PR DESCRIPTION
Log the guid from DfE SignIn to make it easier to support

### Context
Getting errors on prod but can't tell which user it's for.

```
Application started. Press Ctrl+C to shut down.
fail: Microsoft.EntityFrameworkCore.Query[10100]
      An exception occurred in the database while iterating the results of a query for context type 'GovUk.Education.ManageCourses.Domain.DatabaseAccess.ManageCoursesDbContext'.
      System.InvalidOperationException: Sequence contains no elements
         at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
         at lambda_method(Closure , QueryContext )
         at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.<>c__DisplayClass17_1`1.<CompileQueryCore>b__0(QueryContext qc)
System.InvalidOperationException: Sequence contains no elements
   at System.Linq.Enumerable.First[TSource](IEnumerable`1 source)
   at lambda_method(Closure , QueryContext )
at Microsoft.EntityFrameworkCore.Query.Internal.QueryCompiler.<>c__DisplayClass17_1`1.<CompileQueryCore>b__0(QueryContext qc)
```

### Changes proposed in this pull request

Handle unknown users more gracefully

* return 401 from API instead of crashing
* log guid from sign-in service to help troubleshooting

This makes the API more supportable.

When https://github.com/DFE-Digital/manage-courses-ui/pull/68 is merged as well the users will get a better experience.