### PR TITLE
AccessRequests now persist even if a new user list is imported

### DIFF
--- a/src/ManageCourses.Api/Controllers/AccessRequestController.cs
+++ b/src/ManageCourses.Api/Controllers/AccessRequestController.cs
@@ -15,58 +15,30 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
     [Route("api/[controller]")]
     public class AccessRequestController : Controller
     {
-        private readonly IManageCoursesDbContext _context;
-        private readonly IAccessRequestEmailService _emailService;
+        private readonly IAccessRequestService _service;
 
-        public AccessRequestController(IManageCoursesDbContext context, IAccessRequestEmailService emailService)
+        public AccessRequestController(IAccessRequestService accessRequestService)
         {
-            _context = context;
-            _emailService = emailService;
+            _service = accessRequestService;
         }
 
         [Authorize]
         [HttpPost]
-        public async Task<StatusCodeResult> Index([FromBody] AccessRequest request) 
+        public StatusCodeResult Index([FromBody] AccessRequest request) 
         {
             var requesterEmail = this.User.Identity.Name;
-            using (var transaction = ((DbContext)_context).Database.BeginTransaction()) 
+            
+            try
             {
-                try
-                {
-                    var requester = _context.McUsers
-                        .Include(x=>x.McOrganisationUsers)
-                        .ThenInclude(x=>x.McOrganisation).ByEmail(requesterEmail).SingleOrDefault();
-
-                    var requestedIfExists = _context.McUsers
-                        .Include(x=>x.McOrganisationUsers)
-                        .ThenInclude(x=>x.McOrganisation).ByEmail(request.EmailAddress).SingleOrDefault();
-
-                    var orgs = requester.McOrganisationUsers.Select(x => x.McOrganisation.Name);
-                    var entity = _context.AccessRequests.Add(new Domain.Models.AccessRequest() {
-                        RequestDateUtc = System.DateTime.UtcNow,
-                        Requester = requester,
-                        FirstName = request.FirstName,
-                        LastName = request.LastName,
-                        EmailAddress = request.EmailAddress,
-                        Organisation = request.Organisation,
-                        Reason = request.Reason,
-                        Status = Domain.Models.AccessRequest.RequestStatus.Requested
-                    }); 
-                    _context.Save();
-
-                    _emailService.SendAccessRequestEmailToSupport(entity.Entity, requester, requestedIfExists);
-                                        
-                    transaction.Commit();
-                }
-                catch (Exception e)
-                {
-                    transaction.Rollback();
-                    return StatusCode(500);
-                }
-            
-            
-                return StatusCode(200);
+                _service.LogAccessRequest(request, requesterEmail);
             }
+            catch (Exception)
+            {
+                return StatusCode(500);
+            }            
+        
+            return StatusCode(200);
+            
         }
     }
 }

--- a/src/ManageCourses.Api/Data/AccessRequestService.cs
+++ b/src/ManageCourses.Api/Data/AccessRequestService.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
+using static GovUk.Education.ManageCourses.Domain.DatabaseAccess.McUserQueryableExtensions;
 
 namespace GovUk.Education.ManageCourses.Api.Data
 {
@@ -26,13 +27,16 @@ namespace GovUk.Education.ManageCourses.Api.Data
                 try
                 {
                     var requester = _context.McUsers
+                        .ByEmail(requesterEmail)
                         .Include(x=>x.McOrganisationUsers)
                         .ThenInclude(x=>x.McOrganisation)
-                        .Single(x => String.Equals(x.Email, requesterEmail, StringComparison.InvariantCultureIgnoreCase));
+                        .Single();
 
                     var requestedIfExists = _context.McUsers
+                        .ByEmail(request.EmailAddress)
                         .Include(x=>x.McOrganisationUsers)
-                        .ThenInclude(x=>x.McOrganisation).SingleOrDefault(x =>String.Equals(x.Email, request.EmailAddress, StringComparison.InvariantCultureIgnoreCase));
+                        .ThenInclude(x=>x.McOrganisation)
+                        .SingleOrDefault();
 
                     var orgs = requester.McOrganisationUsers.Select(x => x.McOrganisation.Name);
                     var entity = _context.AccessRequests.Add(new Domain.Models.AccessRequest() {

--- a/src/ManageCourses.Api/Data/AccessRequestService.cs
+++ b/src/ManageCourses.Api/Data/AccessRequestService.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
+using Microsoft.EntityFrameworkCore;
+
+namespace GovUk.Education.ManageCourses.Api.Data
+{
+    public class AccessRequestService : IAccessRequestService
+    {
+        
+        private readonly IManageCoursesDbContext _context;
+        private readonly IAccessRequestEmailService _emailService;
+
+        
+        public AccessRequestService(IManageCoursesDbContext context, IAccessRequestEmailService emailService)
+        {
+            _context = context;
+            _emailService = emailService;
+        }
+
+        public void LogAccessRequest(AccessRequest request, string requesterEmail)
+        {
+            using (var transaction = ((DbContext)_context).Database.BeginTransaction()) 
+            {
+                try
+                {
+                    var requester = _context.McUsers
+                        .Include(x=>x.McOrganisationUsers)
+                        .ThenInclude(x=>x.McOrganisation)
+                        .Single(x => String.Equals(x.Email, requesterEmail, StringComparison.InvariantCultureIgnoreCase));
+
+                    var requestedIfExists = _context.McUsers
+                        .Include(x=>x.McOrganisationUsers)
+                        .ThenInclude(x=>x.McOrganisation).SingleOrDefault(x =>String.Equals(x.Email, request.EmailAddress, StringComparison.InvariantCultureIgnoreCase));
+
+                    var orgs = requester.McOrganisationUsers.Select(x => x.McOrganisation.Name);
+                    var entity = _context.AccessRequests.Add(new Domain.Models.AccessRequest() {
+                        RequestDateUtc = System.DateTime.UtcNow,
+                        Requester = requester,
+                        RequesterEmail = requester.Email,
+                        FirstName = request.FirstName,
+                        LastName = request.LastName,
+                        EmailAddress = request.EmailAddress,
+                        Organisation = request.Organisation,
+                        Reason = request.Reason,
+                        Status = Domain.Models.AccessRequest.RequestStatus.Requested
+                    }); 
+                    _context.Save();
+
+                    _emailService.SendAccessRequestEmailToSupport(entity.Entity, requester, requestedIfExists);
+                                        
+                    transaction.Commit();
+                }
+                catch (Exception e)
+                {
+                    transaction.Rollback();
+                    throw;
+                }
+            }
+        }        
+    }
+}

--- a/src/ManageCourses.Api/Data/IAccessRequestService.cs
+++ b/src/ManageCourses.Api/Data/IAccessRequestService.cs
@@ -1,0 +1,9 @@
+using GovUk.Education.ManageCourses.Api.Model;
+
+namespace GovUk.Education.ManageCourses.Api.Data
+{
+    public interface IAccessRequestService
+    {
+        void LogAccessRequest(AccessRequest request, string requesterEmail);
+    }
+}

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -57,11 +57,12 @@ namespace GovUk.Education.ManageCourses.Api
             services.AddScoped<IDataService, DataService>();
             services.AddScoped<IUserLogService, UserLogService>();
 
-            services.AddSingleton<IAccessRequestEmailService>(provider => new EmailServiceFactory(Configuration["email:api_key"])
+            services.AddScoped<IAccessRequestService>(provider => new AccessRequestService(provider.GetService<IManageCoursesDbContext>(),
+                new EmailServiceFactory(Configuration["email:api_key"])
                 .MakeAccessRequestEmailService(
                     Configuration["email:template_id"],
                     Configuration["email:user"]
-                ));
+                )));
 
             services.AddMvc();
         }

--- a/src/ManageCourses.Domain/Migrations/20180710110236_AddRequesterEmailColumn.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180710110236_AddRequesterEmailColumn.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180710110236_AddRequesterEmailColumn")]
+    partial class AddRequesterEmailColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -434,9 +435,6 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
 
                     b.Property<string>("SignInUserId")
                         .HasColumnName("sign_in_user_id");
-
-                    b.Property<string>("UserEmail")
-                        .HasColumnName("user_email");
 
                     b.Property<int?>("UserId")
                         .HasColumnName("user_id");

--- a/src/ManageCourses.Domain/Migrations/20180710110236_AddRequesterEmailColumn.cs
+++ b/src/ManageCourses.Domain/Migrations/20180710110236_AddRequesterEmailColumn.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class AddRequesterEmailColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "requester_email",
+                table: "access_request",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "requester_email",
+                table: "access_request");
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/AccessRequest.cs
+++ b/src/ManageCourses.Domain/Models/AccessRequest.cs
@@ -7,7 +7,9 @@ namespace GovUk.Education.ManageCourses.Domain.Models
     {
         public int Id { get; set; }
         public DateTime RequestDateUtc { get; set; }
+        public int? RequesterId {get;set;}
         public McUser Requester { get; set; }
+        public string RequesterEmail { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string EmailAddress { get; set; }

--- a/tests/ManageCourses.Tests/Integration/AccessRequestServiceTests.cs
+++ b/tests/ManageCourses.Tests/Integration/AccessRequestServiceTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using GovUk.Education.ManageCourses;
+using GovUk.Education.ManageCourses.Api.Data;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
+using GovUk.Education.ManageCourses.Domain.Models;
+using GovUk.Education.ManageCourses.Tests.Integration.DatabaseAccess;
+using Microsoft.EntityFrameworkCore;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.Integration
+{
+    [TestFixture]
+    [Category("Integration")]
+    [Category("Integration_DB")]
+    [Explicit]
+    public class AccessRequestServiceTests : ManageCoursesDbContextIntegrationBase
+    {        
+        private IManageCoursesDbContext Context = null;
+        private AccessRequestService System;
+
+        private MockEmailService EmailService;
+        
+        [SetUp]
+        public void Setup()
+        {
+            Context = this.GetContext();
+            Context.AccessRequests.RemoveRange(Context.AccessRequests);
+            
+            Context.McOrganisationUsers.RemoveRange(Context.McOrganisationUsers);
+            Context.McOrganisations.RemoveRange(Context.McOrganisations);
+            Context.McUsers.RemoveRange(Context.McUsers);
+
+            Context.Save();
+
+            EmailService = new MockEmailService();
+
+            System = new AccessRequestService(Context, EmailService);
+        }
+
+        [Test]
+        public void HappyPath()
+        {
+            Context.AddMcUser(MakeSomeExistingUser());
+            Context.Save();
+
+            System.LogAccessRequest(MakeSomeAccessRequest(), "joe@example.com");
+
+            var savedRequest = Context.AccessRequests.Include(x=>x.Requester).First();
+
+            // Many, many asserts to cover all fields            
+            Assert.AreEqual(MakeSomeAccessRequest().FirstName, savedRequest.FirstName);
+            Assert.AreEqual(MakeSomeAccessRequest().LastName, savedRequest.LastName);
+            Assert.AreEqual(MakeSomeAccessRequest().EmailAddress, savedRequest.EmailAddress);
+            Assert.Less(0, savedRequest.Id);
+            Assert.AreEqual(MakeSomeAccessRequest().Organisation, savedRequest.Organisation);
+            Assert.AreEqual(MakeSomeAccessRequest().Reason, savedRequest.Reason);
+            Assert.AreEqual(Context.McUsers.First().Id, savedRequest.RequesterId);
+            Assert.AreEqual(Context.McUsers.First().Email, savedRequest.RequesterEmail);
+            Assert.AreEqual(Context.McUsers.First().Email, savedRequest.Requester.Email);
+
+            Assert.AreEqual(MakeSomeExistingUser().Email, EmailService.lastRequester.Email);            
+            Assert.AreEqual(MakeSomeExistingUser().FirstName, EmailService.lastRequester.FirstName);            
+            Assert.AreEqual(MakeSomeExistingUser().LastName, EmailService.lastRequester.LastName);
+
+            Assert.AreEqual(MakeSomeExistingUser().McOrganisationUsers.First().McOrganisation.Name, EmailService.lastRequester.McOrganisationUsers.First().McOrganisation.Name);
+
+            Assert.IsNull(EmailService.lastRequested);
+
+            Assert.AreEqual(MakeSomeAccessRequest().FirstName, EmailService.lastAccessRequest.FirstName);
+            Assert.AreEqual(MakeSomeAccessRequest().LastName, EmailService.lastAccessRequest.LastName);
+            Assert.AreEqual(MakeSomeAccessRequest().EmailAddress, EmailService.lastAccessRequest.EmailAddress);
+            Assert.AreEqual(MakeSomeAccessRequest().Organisation, EmailService.lastAccessRequest.Organisation);
+            Assert.AreEqual(MakeSomeAccessRequest().Reason, EmailService.lastAccessRequest.Reason);
+            
+            Assert.AreEqual("joe@example.com", EmailService.lastAccessRequest.RequesterEmail);           
+        }
+
+        [Test]
+        public void RequestedUserExists()
+        {            
+            var user =  MakeSomeExistingUser();
+            var user2 = MakeSomeOtherExistingUser();
+            
+            Context.AddMcUser(user);
+            Context.AddMcUser(user2);
+            Context.Save();
+
+            System.LogAccessRequest(MakeSomeAccessRequest(), "joe@example.com");
+
+            var savedRequest = Context.AccessRequests.Include(x=>x.Requester).First();
+
+            Assert.AreEqual(user2.FirstName, EmailService.lastRequested.FirstName);
+            Assert.AreEqual(user2.LastName, EmailService.lastRequested.LastName);
+            Assert.AreEqual(user2.Email, EmailService.lastRequested.Email);
+        }
+
+        [Test]
+        public void UserDeletion_DoesntDeleteRequest()
+        {
+            var userToDelete = MakeSomeExistingUser();
+
+            Context.AddMcUser(userToDelete);
+            Context.Save();
+
+            System.LogAccessRequest(MakeSomeAccessRequest(), "joe@example.com");
+
+            Context.McUsers.Remove(userToDelete);
+            Context.Save();
+
+            var savedRequest = Context.AccessRequests.Include(x=>x.Requester).First();
+
+            Assert.Less(0, savedRequest.Id);
+            Assert.IsNull(savedRequest.RequesterId);
+            Assert.IsNull(savedRequest.Requester);
+            Assert.AreEqual("joe@example.com", savedRequest.RequesterEmail);
+        }
+
+        [Test]
+        public void RequesterEmailIsCaseInsensitive()
+        {
+            var user =  MakeSomeExistingUser();
+
+            Context.AddMcUser(user);
+            Context.Save();
+
+            System.LogAccessRequest(MakeSomeAccessRequest(), "JoE@eXaMpLE.CoM");
+
+            var savedRequest = Context.AccessRequests.Include(x=>x.Requester).First();
+
+            Assert.Less(0, savedRequest.Id);
+            Assert.AreEqual("joe@example.com", savedRequest.RequesterEmail);
+            Assert.AreEqual("joe@example.com", savedRequest.Requester.Email);
+        }
+
+        [Test]
+        public void RequestedEmailIsCaseInsensitive()
+        {
+            var user =  MakeSomeExistingUser();
+            var user2 = MakeSomeOtherExistingUser();            
+
+            Context.AddMcUser(user);
+            Context.AddMcUser(user2);
+            Context.Save();
+
+            var accessRequest = MakeSomeAccessRequest();
+            accessRequest.EmailAddress = "jAnE@eXaMpLe.CoM";
+            System.LogAccessRequest(accessRequest, "joe@example.com");
+
+            var savedRequest = Context.AccessRequests.Include(x=>x.Requester).First();
+
+            Assert.Less(0, savedRequest.Id);
+            Assert.AreEqual("jane@example.com", EmailService.lastRequested.Email);
+        }
+
+        [Test]
+        public void NonexistentRequester_Throws()
+        {
+            try 
+            {
+                System.LogAccessRequest(MakeSomeAccessRequest(), "joe@example.com");
+            }
+            catch
+            {
+                Assert.AreEqual(0, Context.AccessRequests.Count());
+                Assert.IsNull(EmailService.lastAccessRequest);
+                return;
+            }
+            Assert.Fail("Should have thrown");
+        }
+
+        [Test]
+        public void EmailError_RollsBackAccessRequest()
+        {
+            Context.AddMcUser(MakeSomeExistingUser());
+            Context.Save();
+
+            System = new AccessRequestService(Context, new ErroringEmailService());
+            try 
+            {
+                System.LogAccessRequest(MakeSomeAccessRequest(), "joe@example.com");
+            }
+            catch
+            {
+                Assert.AreEqual(0, Context.AccessRequests.Count());
+                return;
+            }
+
+            Assert.Fail("Should have thrown");
+        }
+
+        private McUser MakeSomeExistingUser() 
+        {
+            var res = new McUser() {
+                FirstName = "Joe",
+                LastName = "Bloggs",
+                Email = "joe@example.com"
+            };
+
+            res.McOrganisationUsers = new Collection<McOrganisationUser> {
+                    new McOrganisationUser 
+                    {
+                        McUser = res,
+                        McOrganisation = new McOrganisation {
+                            Name = "Joe's school",
+                            OrgId = "123"
+                        }                        
+                    }
+                };
+            
+            return res;
+        }
+
+        private McUser MakeSomeOtherExistingUser() 
+        {
+            return new McUser() {
+                FirstName = "Jane",
+                LastName = "Doe",
+                Email = "jane@example.com"
+            };
+        }
+
+        private Api.Model.AccessRequest MakeSomeAccessRequest()
+        {
+            return new Api.Model.AccessRequest {
+                FirstName = "Jane",
+                LastName = "Doe",
+                EmailAddress = "jane@example.com",
+                Organisation = "Joe and Jane's happy school",
+                Reason = "Jane is doing all the prose"
+            };
+        }
+
+        private class ErroringEmailService : IAccessRequestEmailService
+        {
+            public void SendAccessRequestEmailToSupport(AccessRequest accessRequest, McUser requester, McUser requestedOrNull)
+            {
+                throw new SuperUnexpectedException();
+            }
+        }
+
+        private class SuperUnexpectedException : Exception
+        {
+
+        }
+
+        private class MockEmailService : IAccessRequestEmailService
+        {
+            public AccessRequest lastAccessRequest = null;
+            public McUser lastRequester = null;
+            public McUser lastRequested = null;
+
+            public int called = 0;
+            public void SendAccessRequestEmailToSupport(AccessRequest accessRequest, McUser requester, McUser requestedOrNull)
+            {
+                called++;
+                lastAccessRequest = accessRequest;
+                lastRequester = requester;
+                lastRequested = requestedOrNull;
+            }
+        }
+
+
+    }
+}


### PR DESCRIPTION
### Context

Often we import new data, be it a new data dump from UCAS or a refined user list. This involves deleting old data, but the presence of access requests lead to FK violations.

### Changes proposed in this pull request

This makes references in an AccessRequest to an existing user optional, while also adding RequesterEmail field. When the user list gets refreshed, existing requests are orphaned from their McUser but remain actionable since RequesterEmail can be matched up to the new corresponding McUser record

### Guidance to review

The actual functional change is just the two lines in AccessRequest.cs, that's all that was needed. 

But I used the opportunity to add tests for AccessRequests! All other code changes are refactorings to make AccessRequests testable, particularly splitting out an AccessRequestService from the controller.
