### PR TITLE
Case insensitive user lookups by email

### DIFF
--- a/src/ManageCourses.Api/Controllers/AccessRequestController.cs
+++ b/src/ManageCourses.Api/Controllers/AccessRequestController.cs
@@ -35,11 +35,11 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
                 {
                     var requester = _context.McUsers
                         .Include(x=>x.McOrganisationUsers)
-                        .ThenInclude(x=>x.McOrganisation).Single(x => x.Email == requesterEmail);
+                        .ThenInclude(x=>x.McOrganisation).ByEmail(requesterEmail).SingleOrDefault();
 
                     var requestedIfExists = _context.McUsers
                         .Include(x=>x.McOrganisationUsers)
-                        .ThenInclude(x=>x.McOrganisation).SingleOrDefault(x => x.Email == request.EmailAddress);
+                        .ThenInclude(x=>x.McOrganisation).ByEmail(request.EmailAddress).SingleOrDefault();
 
                     var orgs = requester.McOrganisationUsers.Select(x => x.McOrganisation.Name);
                     var entity = _context.AccessRequests.Add(new Domain.Models.AccessRequest() {

--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -42,7 +42,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                 {
                     var userDetails = GetJsonUserDetails(accessToken);
 
-                    var mcuser = _manageCoursesDbContext.McUsers.FirstOrDefault(x => x.Email == userDetails.Email);
+                    var mcuser = _manageCoursesDbContext.McUsers.ByEmail(userDetails.Email).SingleOrDefault();
                     if (mcuser == null)
                     {
                         Logger.LogWarning($"SignIn subject {userDetails.Subject} not found in McUsers data");

--- a/src/ManageCourses.Api/Services/UserLogService.cs
+++ b/src/ManageCourses.Api/Services/UserLogService.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
             {
                 try
                 {
-                    var user = _context.McUsers.SingleOrDefault(x => x.Email == email);
+                    var user = _context.McUsers.ByEmail(email).SingleOrDefault();
 
                     var userLog = _context.UserLogs
                         .Include(x => x.User)

--- a/src/ManageCourses.Domain/DatabaseAccess/McUserQueryableExtensions.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/McUserQueryableExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Linq;
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
+{
+    public static class McUserQueryableExtensions
+    {
+        /// <summary>
+        /// Case insensitive filter for users by email address.
+        /// This should be used for all lookups by email even for OrganisationUser to keep logic consistent.
+        /// Follow this with .SingleOrDefault to get an actuall McUser object (don't forget to check for nulls!).
+        /// </summary>
+        public static IQueryable<McUser> ByEmail(this IQueryable<McUser> mcUsers, string email)
+        {
+            return mcUsers.Where(user => string.Equals(user.Email, email, StringComparison.InvariantCultureIgnoreCase));
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/McUserByEmailTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/McUserByEmailTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
+using GovUk.Education.ManageCourses.Domain.Models;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting
+{
+    [TestFixture]
+    public class McUserByEmailTests
+    {
+        const string FredExampleOrg = "fred@example.org";
+        private const string WilmaExampleOrg = "wilma@example.org";
+        private const int FredId = 11;
+        private const int WilmaId = 12;
+        private IQueryable<McUser> _mcUsers;
+
+        [SetUp]
+        public void Setup()
+        {
+            _mcUsers = new List<McUser> {
+                new McUser {Id = FredId, Email = FredExampleOrg },
+                new McUser {Id = WilmaId, Email = WilmaExampleOrg },
+            }.AsQueryable();
+        }
+
+        [Test]
+        [TestCase(FredExampleOrg, FredId)]
+        [TestCase(WilmaExampleOrg, WilmaId)]
+        [TestCase("no-one@example.org", null)]
+        public void Test_McUser_ByEmail(string email, int? expectedId)
+        {
+            TestByEmailVariation(email, expectedId);
+            TestByEmailVariation(email.ToUpper(), expectedId);
+        }
+
+        private void TestByEmailVariation(string email, int? exectedId)
+        {
+            var mcUser = _mcUsers.ByEmail(email).SingleOrDefault();
+
+            if (exectedId != null)
+            {
+                mcUser.Should().NotBeNull();
+                mcUser.Id.Should().Be(exectedId);
+            }
+            else
+            {
+                mcUser.Should().BeNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Context
Users registered with different case of email on sign-in vs our user list couldn't see any courses.

### Changes proposed in this pull request
Single method for comparing email addresses + tests and updating all usages.

Replaces #48