### PR TITLE
Userlog now persists even when we import new users

### DIFF
--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -57,7 +57,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                     
                     var princical = new ClaimsPrincipal(identity);
 
-                    _userLogService.CreateOrUpdateUserLog(userDetails.Subject, userDetails.Email);
+                    _userLogService.CreateOrUpdateUserLog(userDetails.Subject, mcuser);
                     var ticket = new AuthenticationTicket(princical, BearerTokenDefaults.AuthenticationScheme);
 
                     return AuthenticateResult.Success(ticket);

--- a/src/ManageCourses.Api/Services/IUserLogService.cs
+++ b/src/ManageCourses.Api/Services/IUserLogService.cs
@@ -1,7 +1,9 @@
+using GovUk.Education.ManageCourses.Domain.Models;
+
 namespace GovUk.Education.ManageCourses.Api.Services
 {
     public interface IUserLogService
     {
-        bool CreateOrUpdateUserLog(string signInUserId, string email);
+        bool CreateOrUpdateUserLog(string signInUserId, McUser user);
     }
 }

--- a/src/ManageCourses.Api/Services/UserLogService.cs
+++ b/src/ManageCourses.Api/Services/UserLogService.cs
@@ -15,18 +15,15 @@ namespace GovUk.Education.ManageCourses.Api.Services
             _context = context;
         }
 
-        public bool CreateOrUpdateUserLog(string signInUserId, string email) 
+        public bool CreateOrUpdateUserLog(string signInUserId, McUser user) 
         {
             var result = false;
             using (var transaction = ((DbContext)_context).Database.BeginTransaction()) 
             {
                 try
                 {
-                    var user = _context.McUsers.ByEmail(email).SingleOrDefault();
-
                     var userLog = _context.UserLogs
-                        .Include(x => x.User)
-                        .SingleOrDefault(x => (user != null ? x.User == user : true || !string.IsNullOrEmpty(x.UserEmail) ? string.Equals(x.UserEmail, email, StringComparison.InvariantCultureIgnoreCase) : true ) && x.SignInUserId == signInUserId);
+                        .SingleOrDefault(x => x.SignInUserId == signInUserId);
 
                     var add = userLog == null;
                     if (add)

--- a/src/ManageCourses.Api/Services/UserLogService.cs
+++ b/src/ManageCourses.Api/Services/UserLogService.cs
@@ -26,7 +26,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
 
                     var userLog = _context.UserLogs
                         .Include(x => x.User)
-                        .SingleOrDefault(x => (user != null ? x.User == user : true || string.Equals(x.UserEmail, email, StringComparison.InvariantCultureIgnoreCase) ) && x.SignInUserId == signInUserId);
+                        .SingleOrDefault(x => (user != null ? x.User == user : true || !string.IsNullOrEmpty(x.UserEmail) ? string.Equals(x.UserEmail, email, StringComparison.InvariantCultureIgnoreCase) : true ) && x.SignInUserId == signInUserId);
 
                     var add = userLog == null;
                     if (add)

--- a/src/ManageCourses.Api/Services/UserLogService.cs
+++ b/src/ManageCourses.Api/Services/UserLogService.cs
@@ -26,7 +26,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
 
                     var userLog = _context.UserLogs
                         .Include(x => x.User)
-                        .SingleOrDefault(x => (user != null ? x.User == user : true) && x.SignInUserId == signInUserId);
+                        .SingleOrDefault(x => (user != null ? x.User == user : true || string.Equals(x.UserEmail, email, StringComparison.InvariantCultureIgnoreCase) ) && x.SignInUserId == signInUserId);
 
                     var add = userLog == null;
                     if (add)
@@ -39,6 +39,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
                     }
 
                     userLog.User = user;
+                    userLog.UserEmail = user.Email;
                     userLog.LastLoginDateUtc = DateTime.UtcNow;
 
                     if (add)

--- a/src/ManageCourses.Domain/Migrations/20180710162624_AddUserEmailColumn.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180710162624_AddUserEmailColumn.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180710162624_AddUserEmailColumn")]
+    partial class AddUserEmailColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20180710162624_AddUserEmailColumn.cs
+++ b/src/ManageCourses.Domain/Migrations/20180710162624_AddUserEmailColumn.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class AddUserEmailColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "user_email",
+                table: "user_log",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "user_email",
+                table: "user_log");
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/UserLog.cs
+++ b/src/ManageCourses.Domain/Models/UserLog.cs
@@ -7,7 +7,9 @@ namespace GovUk.Education.ManageCourses.Domain.Models
     {
         public int Id { get; set; }
         public DateTime FirstLoginDateUtc { get; set; }
+        public int? UserId { get; set; }
         public McUser User { get; set; }
+        public string UserEmail { get; set; }
         public DateTime LastLoginDateUtc { get; set; }
         public string SignInUserId { get; set; }
     }

--- a/tests/ManageCourses.Tests/Integration/UserLogServiceTests.cs
+++ b/tests/ManageCourses.Tests/Integration/UserLogServiceTests.cs
@@ -111,5 +111,27 @@ namespace GovUk.Education.ManageCourses.Tests.Integration
 
             Assert.AreEqual(1, Context.UserLogs.Count());
         }
+
+        [Test]
+        public void CreateOrUpdateUserLog_Deleted_MCuser()
+        {
+            var email = TestUserEmail_1;
+            var signInUserId = "signInUserId";
+            var result = Subject.CreateOrUpdateUserLog(signInUserId, email);
+
+            Assert.IsTrue(result);
+
+            Assert.AreEqual(1, Context.UserLogs.Count());
+
+            Assert.IsNotNull(Context.UserLogs.Include(x => x.User).First().User);
+            var firstUser = Context.McUsers.First(x => x.Email == email);
+            Context.McUsers.Remove(firstUser);
+            Context.Save();
+
+            Assert.AreEqual(1, Context.UserLogs.Count());
+            Assert.AreEqual(TestUserEmail_1, Context.UserLogs.First().UserEmail);
+
+            Assert.IsNull(Context.UserLogs.Include(x => x.User).First().User);
+        }
     }
 }

--- a/tests/ManageCourses.Tests/Integration/UserLogServiceTests.cs
+++ b/tests/ManageCourses.Tests/Integration/UserLogServiceTests.cs
@@ -21,17 +21,27 @@ namespace GovUk.Education.ManageCourses.Tests.Integration
         private const string TestUserEmail_1 = "email_1@test-manage-courses.gov.uk";
         private const string TestUserEmail_2 = "email_2@test-manage-courses.gov.uk";
 
+        private static McUser User1 = new McUser
+        {
+            FirstName = "FirstName_1",
+            LastName = "LastName_1",
+            Email = TestUserEmail_1
+        };
+
+        private static McUser User2 = new McUser
+        {
+            FirstName = "FirstName_2",
+            LastName = "LastName_2",
+            Email = TestUserEmail_2
+        };
+
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
             Context = this.GetContext();
 
-            Context.AddMcUser(new McUser
-            {
-                FirstName = "FirstName_1",
-                LastName = "LastName_1",
-                Email = TestUserEmail_1
-            });
+            Context.AddMcUser(User1);
+            Context.AddMcUser(User2);
 
             Context.Save();
 
@@ -63,7 +73,7 @@ namespace GovUk.Education.ManageCourses.Tests.Integration
             Context.Save();
             var email = TestUserEmail_1;
             
-            var result = Subject.CreateOrUpdateUserLog(signInUserId, email);
+            var result = Subject.CreateOrUpdateUserLog(signInUserId, User1);
 
             Assert.IsTrue(result);
 
@@ -80,13 +90,13 @@ namespace GovUk.Education.ManageCourses.Tests.Integration
         {
             var email = TestUserEmail_1;
             var signInUserId = "signInUserId";
-            var result = Subject.CreateOrUpdateUserLog(signInUserId, email);
+            var result = Subject.CreateOrUpdateUserLog(signInUserId, User1);
 
             Assert.IsTrue(result);
 
             Assert.AreEqual(1, Context.UserLogs.Count());
 
-            var result2 = Subject.CreateOrUpdateUserLog(signInUserId + 2, TestUserEmail_2);
+            var result2 = Subject.CreateOrUpdateUserLog(signInUserId + 2, User2);
 
             Assert.IsTrue(result2);
 
@@ -99,13 +109,13 @@ namespace GovUk.Education.ManageCourses.Tests.Integration
         {
             var email = TestUserEmail_1;
             var signInUserId = "signInUserId";
-            var result = Subject.CreateOrUpdateUserLog(signInUserId, email);
+            var result = Subject.CreateOrUpdateUserLog(signInUserId, User1);
 
             Assert.IsTrue(result);
 
             Assert.AreEqual(1, Context.UserLogs.Count());
 
-            var result2 = Subject.CreateOrUpdateUserLog(signInUserId, TestUserEmail_2);
+            var result2 = Subject.CreateOrUpdateUserLog(signInUserId, User2);
 
             Assert.IsTrue(result2);
 
@@ -117,7 +127,7 @@ namespace GovUk.Education.ManageCourses.Tests.Integration
         {
             var email = TestUserEmail_1;
             var signInUserId = "signInUserId";
-            var result = Subject.CreateOrUpdateUserLog(signInUserId, email);
+            var result = Subject.CreateOrUpdateUserLog(signInUserId, User1);
 
             Assert.IsTrue(result);
 


### PR DESCRIPTION
### Context
Similar to AccessRequest #50
Often we import new data, be it a new data dump from UCAS or a refined user list. This involves deleting old data, but the presence of access requests lead to FK violations.

### Changes proposed in this pull request

This makes references in an UserLog to an existing user optional, while also adding UserEmail field. When the user list gets refreshed, existing requests are orphaned from their McUser but remain actionable since UserEmail can be matched up to the new corresponding McUser record

### Guidance to review

