### PR TITLE
Set UserLog.UserId and AccessRequest.RequesterId to null when the cor…

### DIFF
--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -106,6 +106,18 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                 .HasForeignKey(ucs => new { ucs.InstCode, ucs.CrseCode })
                 .HasPrincipalKey(cc => new { cc.InstCode, cc.CrseCode });
 
+            modelBuilder.Entity<AccessRequest>()
+                .HasOne(ar => ar.Requester)
+                .WithMany(u => u.AccessRequests)
+                .HasForeignKey(ar => ar.RequesterId)
+                .OnDelete(DeleteBehavior.SetNull);
+
+            modelBuilder.Entity<UserLog>()
+                .HasOne(ul => ul.User)
+                .WithMany(u => u.UserLogs)
+                .HasForeignKey(ul => ul.UserId)
+                .OnDelete(DeleteBehavior.SetNull);                
+
             base.OnModelCreating(modelBuilder);
         }
 

--- a/src/ManageCourses.Domain/Migrations/20180711143718_MakeRequesterAndLogUserNullable.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180711143718_MakeRequesterAndLogUserNullable.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180711143718_MakeRequesterAndLogUserNullable")]
+    partial class MakeRequesterAndLogUserNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20180711143718_MakeRequesterAndLogUserNullable.cs
+++ b/src/ManageCourses.Domain/Migrations/20180711143718_MakeRequesterAndLogUserNullable.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class MakeRequesterAndLogUserNullable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_access_request_mc_user_requester_id",
+                table: "access_request");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_user_log_mc_user_user_id",
+                table: "user_log");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_access_request_mc_user_requester_id",
+                table: "access_request",
+                column: "requester_id",
+                principalTable: "mc_user",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_user_log_mc_user_user_id",
+                table: "user_log",
+                column: "user_id",
+                principalTable: "mc_user",
+                principalColumn: "id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_access_request_mc_user_requester_id",
+                table: "access_request");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_user_log_mc_user_user_id",
+                table: "user_log");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_access_request_mc_user_requester_id",
+                table: "access_request",
+                column: "requester_id",
+                principalTable: "mc_user",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_user_log_mc_user_user_id",
+                table: "user_log",
+                column: "user_id",
+                principalTable: "mc_user",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/McUser.cs
+++ b/src/ManageCourses.Domain/Models/McUser.cs
@@ -10,5 +10,8 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string Email { get; set; }
 
         public ICollection<McOrganisationUser> McOrganisationUsers { get; set; }
+        public ICollection<AccessRequest> AccessRequests { get; set; }
+        
+        public ICollection<UserLog> UserLogs { get; set; }  
     }
 }


### PR DESCRIPTION
Set UserLog.UserId and AccessRequest.RequesterId to null when the corresponding user is deleted

### Context
We sometimes reimport users, which orphans access requests and user logs

### Changes proposed in this pull request
Deleting users currently fails because the delete behaviour is set to `restrict`, rather than set null

### Guidance to review
There are two more entries in the DbContext fluent API (at the bottom)

EF Core requires us to introduce additional navigation properties from McUser to the dependent records, which is not particularly clean but unfortunately neccessary in order to set the OnDelete behaviour :(
