### PR TITLE
Troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project follows https://semver.org/ version numbering.
 In a windows command prompt:
 
     cd src/ManageCourses.Api
-    set ASPNETCORE_URLS=http://*:6001 && dotnet run
+    dotnet run
 
 ## Config
 

--- a/src/ManageCourses.Api/ManageCourses.Api.csproj
+++ b/src/ManageCourses.Api/ManageCourses.Api.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Notify" Version="2.0.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.12" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.4" />

--- a/src/ManageCourses.Api/Program.cs
+++ b/src/ManageCourses.Api/Program.cs
@@ -1,25 +1,45 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Events;
 
 namespace GovUk.Education.ManageCourses.Api
 {
     public class Program
     {
-        public static void Main(string[] args)
+        public static int Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            // this template Main definition is as directed by https://github.com/serilog/serilog-aspnetcore
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .Enrich.FromLogContext()
+                .WriteTo.Console()
+                .CreateLogger();
+
+            try
+            {
+                Log.Information("Starting web host");
+                BuildWebHost(args).Run();
+                return 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Host terminated unexpectedly");
+                return 1;
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .UseSerilog()
                 .Build();
     }
 }

--- a/src/ManageCourses.Api/Properties/launchSettings.json
+++ b/src/ManageCourses.Api/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "http://localhost:60699/"
+      "applicationUrl": "http://localhost:6001/"
     }
   }
 }


### PR DESCRIPTION
### Context

Unable to match errors in prod to info from users due to lack of timestamps etc.

### Changes proposed in this pull request

* Add & configure Serilog to be the logger for the entire API instead of the default dotnet core logger.
* Correction to command-line instructions & config

### Guidance to review

Fire it up with `dotnet run` to see the pretty colours in the console.