### PR TITLE
Allow Serilog to be configured without code changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ https://docs.microsoft.com/en-us/aspnet/core/security/app-secrets?view=aspnetcor
 
 https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/389349377/Manage+Courses+API
 
+## Logging
+
+Logging is configured in `appsettings.json`, and values in there can be overridden with environment variables.
+
+Powershell:
+
+    $env:Serilog:MinimumLevel="Debug"
+    dotnet run
+
+Command prompt
+
+    set Serilog:MinimumLevel=Debug
+    dotnet run
+
+For more information see:
+
+* https://github.com/serilog/serilog-settings-configuration
+* https://nblumhardt.com/2016/07/serilog-2-minimumlevel-override/
+
 # Using the API
 
 The API exposes swagger at `/swagger` thanks to [NSwag](https://github.com/RSuter/NSwag)

--- a/src/ManageCourses.Api/ManageCourses.Api.csproj
+++ b/src/ManageCourses.Api/ManageCourses.Api.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Notify" Version="2.0.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.12" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
   <ItemGroup>
@@ -20,5 +21,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ManageCourses.Domain\ManageCourses.Domain.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/ManageCourses.Api/Program.cs
+++ b/src/ManageCourses.Api/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
 using Serilog;
-using Serilog.Events;
 
 namespace GovUk.Education.ManageCourses.Api
 {
@@ -10,13 +10,18 @@ namespace GovUk.Education.ManageCourses.Api
     {
         public static int Main(string[] args)
         {
-            // this template Main definition is as directed by https://github.com/serilog/serilog-aspnetcore
+            // Logging setup based on https://github.com/serilog/serilog-aspnetcore
+            // and https://github.com/serilog/serilog-settings-configuration
+
+            var configuration = new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json")
+                .AddEnvironmentVariables()
+                .Build();
 
             Log.Logger = new LoggerConfiguration()
-                .MinimumLevel.Debug()
-                .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
+                .ReadFrom.Configuration(configuration)
                 .Enrich.FromLogContext()
-                .WriteTo.Console()
+                .WriteTo.Console() // todo: This should be respecting the value in appsettings, not sure why that's not working
                 .CreateLogger();
 
             try

--- a/src/ManageCourses.Api/appsettings.Development.json
+++ b/src/ManageCourses.Api/appsettings.Development.json
@@ -1,10 +1,11 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": false,
-    "LogLevel": {
+  "Serilog": {
+    "MinimumLevel": {
       "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
     }
   },
   "email": {

--- a/src/ManageCourses.Api/appsettings.json
+++ b/src/ManageCourses.Api/appsettings.json
@@ -1,14 +1,10 @@
 ﻿{
-  "Logging": {
-    "IncludeScopes": false,
-    "Debug": {
-      "LogLevel": {
-        "Default": "Warning"
-      }
-    },
-    "Console": {
-      "LogLevel": {
-        "Default": "Warning"
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+        "Microsoft": "Error",
+        "System": "Error"
       }
     }
   }


### PR DESCRIPTION
Turn logging down to minimum level of Warning

### Context

Logs on prod are too noisy to be useful, current code requires code change to alter noise level.

### Changes proposed in this pull request

Make configurable via json and/or environment variables

### Guidance to review

Take a look at the readme diff for usage.
