### PR TITLE
Improved the logger

### DIFF
--- a/src/ManageCourses.Api/Program.cs
+++ b/src/ManageCourses.Api/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -8,20 +9,17 @@ namespace GovUk.Education.ManageCourses.Api
 {
     public class Program
     {
+        public static IConfiguration Configuration { get; } = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
+
         public static int Main(string[] args)
         {
-            // Logging setup based on https://github.com/serilog/serilog-aspnetcore
-            // and https://github.com/serilog/serilog-settings-configuration
-
-            var configuration = new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json")
-                .AddEnvironmentVariables()
-                .Build();
-
             Log.Logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(configuration)
-                .Enrich.FromLogContext()
-                .WriteTo.Console() // todo: This should be respecting the value in appsettings, not sure why that's not working
+                .ReadFrom.Configuration(Configuration)
                 .CreateLogger();
 
             try

--- a/src/ManageCourses.Api/appsettings.json
+++ b/src/ManageCourses.Api/appsettings.json
@@ -1,11 +1,21 @@
 ﻿{
   "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
     "MinimumLevel": {
       "Default": "Warning",
       "Override": {
         "Microsoft": "Error",
         "System": "Error"
       }
-    }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext:000}] {Message:lj} {NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext" ]
   }
 }


### PR DESCRIPTION

### Context
The logger was hand cranked instead of configuration as well as it was ignoring development appsettings.

### Changes proposed in this pull request
Amended the logger creation to use the appsettings inclusive of development appsettings.

### Guidance to review
![image](https://user-images.githubusercontent.com/470137/42938419-1f0225d6-8b4a-11e8-9ea9-565681f4f347.png)

