### PR TITLE
Removed server header as its can be a security issue

### DIFF
--- a/src/ManageCourses.Api/Program.cs
+++ b/src/ManageCourses.Api/Program.cs
@@ -41,6 +41,10 @@ namespace GovUk.Education.ManageCourses.Api
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
+                .UseKestrel(options => 
+                {
+                    options.AddServerHeader = false;
+                })
                 .UseStartup<Startup>()
                 .UseSerilog()
                 .Build();


### PR DESCRIPTION
### Context
security issue

### Changes proposed in this pull request
Removed server header as its can be a security issue

### Guidance to review
Header response now long shows `Server: Kestrel`

