### PR TITLE
Added invite template email functionality

### DIFF
--- a/src/ManageCourses.Api/Controllers/InviteController.cs
+++ b/src/ManageCourses.Api/Controllers/InviteController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using GovUk.Education.ManageCourses.Api.Middleware;
+using GovUk.Education.ManageCourses.Api.Services.Email;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {
@@ -9,6 +10,13 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
     [Route("api/[controller]")]
     public class InviteController : Controller
     {
+        private readonly IInviteEmailService _inviteEmailService;
+
+        public InviteController(IInviteEmailService inviteEmailService)
+        {
+            _inviteEmailService = inviteEmailService;
+        }
+
         [HttpPost]
         public IActionResult Index() 
         {

--- a/src/ManageCourses.Api/Services/Email/Config/IInviteTemplateEmailConfig.cs
+++ b/src/ManageCourses.Api/Services/Email/Config/IInviteTemplateEmailConfig.cs
@@ -1,0 +1,9 @@
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+
+namespace GovUk.Education.ManageCourses.Api.Services.Email.Config
+{
+    public interface IInviteTemplateEmailConfig : ITemplateEmailConfig<InviteEmailModel>
+    {
+    }
+}
+

--- a/src/ManageCourses.Api/Services/Email/Config/InviteTemplateEmailConfig.cs
+++ b/src/ManageCourses.Api/Services/Email/Config/InviteTemplateEmailConfig.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Configuration;
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+
+namespace GovUk.Education.ManageCourses.Api.Services.Email.Config
+{
+    public class InviteTemplateEmailConfig : TemplateEmailConfig<InviteEmailModel>, IInviteTemplateEmailConfig
+    {
+        public override string ConfigId => "email:invite_template_id";
+        public InviteTemplateEmailConfig(IConfiguration configuration): base(configuration)
+        {
+        }
+    }
+}
+

--- a/src/ManageCourses.Api/Services/Email/IInviteEmailService.cs
+++ b/src/ManageCourses.Api/Services/Email/IInviteEmailService.cs
@@ -1,0 +1,8 @@
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+
+namespace GovUk.Education.ManageCourses.Api.Services.Email
+{
+    public interface IInviteEmailService : ITemplateEmailService<InviteEmailModel>
+    {
+    }
+}

--- a/src/ManageCourses.Api/Services/Email/InviteEmailService.cs
+++ b/src/ManageCourses.Api/Services/Email/InviteEmailService.cs
@@ -1,0 +1,13 @@
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+using GovUk.Education.ManageCourses.Api.Services.Email.Config;
+
+namespace GovUk.Education.ManageCourses.Api.Services.Email
+{
+    public class InviteEmailService : TemplateEmailService<InviteEmailModel>, IInviteEmailService
+    {
+        public InviteEmailService(INotificationClientWrapper noticationClientWrapper, IInviteTemplateEmailConfig config)
+            : base(noticationClientWrapper, config)
+        {
+        }
+    }
+}

--- a/src/ManageCourses.Api/Services/Email/Model/InviteEmailModel.cs
+++ b/src/ManageCourses.Api/Services/Email/Model/InviteEmailModel.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Api.Services.Email.Model
+{
+    public class InviteEmailModel : IEmailModel
+    {
+        public string EmailAddress { get; private set; }
+        public Dictionary<string, dynamic> Personalisation { get; private set; }
+
+        public InviteEmailModel(McUser user)
+        {
+            var personalisation = new Dictionary<string, dynamic>() { { "first_name", user.FirstName?.Trim() } };
+            this.EmailAddress = user.Email;
+            this.Personalisation = personalisation;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -58,8 +58,10 @@ namespace GovUk.Education.ManageCourses.Api
             services.AddScoped<IWelcomeEmailService, WelcomeEmailService>();
             services.AddScoped<IClock, Clock>();
 
-            services.AddScoped<IAccessRequestService>(provider =>
-            {
+            services.AddScoped<IInviteTemplateEmailConfig, InviteTemplateEmailConfig>();
+            services.AddScoped<IInviteEmailService, InviteEmailService>();
+
+            services.AddScoped<IAccessRequestService>(provider => {
                 return new AccessRequestService(provider.GetService<IManageCoursesDbContext>(),
                  new EmailServiceFactory(Configuration["email:api_key"])
                  .MakeAccessRequestEmailService(

--- a/src/ManageCourses.ApiClient/Generated/ManageCoursesApiClient.cs
+++ b/src/ManageCourses.ApiClient/Generated/ManageCoursesApiClient.cs
@@ -257,6 +257,74 @@ namespace GovUk.Education.ManageCourses.ApiClient
             }
         }
     
+        /// <exception cref="SwaggerException">A server side error occurred.</exception>
+        public System.Threading.Tasks.Task<FileResponse> Invite_IndexAsync()
+        {
+            return Invite_IndexAsync(System.Threading.CancellationToken.None);
+        }
+    
+        /// <exception cref="SwaggerException">A server side error occurred.</exception>
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        public async System.Threading.Tasks.Task<FileResponse> Invite_IndexAsync(System.Threading.CancellationToken cancellationToken)
+        {
+            var urlBuilder_ = new System.Text.StringBuilder();
+            urlBuilder_.Append(BaseUrl != null ? BaseUrl.TrimEnd('/') : "").Append("/api/Invite");
+    
+            var client_ = _httpClient;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Content = new System.Net.Http.StringContent(string.Empty, System.Text.Encoding.UTF8, "application/json");
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+                    request_.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
+    
+                    PrepareRequest(client_, request_, urlBuilder_);
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+                    PrepareRequest(client_, request_, url_);
+    
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var headers_ = System.Linq.Enumerable.ToDictionary(response_.Headers, h_ => h_.Key, h_ => h_.Value);
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+    
+                        ProcessResponse(client_, response_);
+    
+                        var status_ = ((int)response_.StatusCode).ToString();
+                        if (status_ == "200" || status_ == "206") 
+                        {
+                            var responseStream_ = response_.Content == null ? System.IO.Stream.Null : await response_.Content.ReadAsStreamAsync().ConfigureAwait(false);
+                            var fileResponse_ = new FileResponse((int)response_.StatusCode, headers_, responseStream_, null, response_); 
+                            client_ = null; response_ = null; // response and client are disposed by FileResponse
+                            return fileResponse_;
+                        }
+                        else
+                        if (status_ != "200" && status_ != "204")
+                        {
+                            var responseData_ = response_.Content == null ? null : await response_.Content.ReadAsStringAsync().ConfigureAwait(false); 
+                            throw new SwaggerException("The HTTP status code of the response was not expected (" + (int)response_.StatusCode + ").", (int)response_.StatusCode, responseData_, headers_, null);
+                        }
+            
+                        return default(FileResponse);
+                    }
+                    finally
+                    {
+                        if (response_ != null)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+            }
+        }
+    
         /// <summary>Exports the data.</summary>
         /// <returns>The exported data</returns>
         /// <exception cref="SwaggerException">A server side error occurred.</exception>
@@ -2177,9 +2245,12 @@ namespace GovUk.Education.ManageCourses.ApiClient
         private string _firstName;
         private string _lastName;
         private string _email;
+        private string _signInUserId;
+        private System.DateTime? _firstLoginDateUtc;
+        private System.DateTime? _lastLoginDateUtc;
+        private System.DateTime? _welcomeEmailDateUtc;
         private System.Collections.ObjectModel.ObservableCollection<McOrganisationUser> _mcOrganisationUsers;
         private System.Collections.ObjectModel.ObservableCollection<AccessRequest2> _accessRequests;
-        private System.Collections.ObjectModel.ObservableCollection<UserLog> _userLogs;
     
         [Newtonsoft.Json.JsonProperty("Id", Required = Newtonsoft.Json.Required.Always)]
         public int Id
@@ -2237,6 +2308,62 @@ namespace GovUk.Education.ManageCourses.ApiClient
             }
         }
     
+        [Newtonsoft.Json.JsonProperty("SignInUserId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string SignInUserId
+        {
+            get { return _signInUserId; }
+            set 
+            {
+                if (_signInUserId != value)
+                {
+                    _signInUserId = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
+    
+        [Newtonsoft.Json.JsonProperty("FirstLoginDateUtc", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime? FirstLoginDateUtc
+        {
+            get { return _firstLoginDateUtc; }
+            set 
+            {
+                if (_firstLoginDateUtc != value)
+                {
+                    _firstLoginDateUtc = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
+    
+        [Newtonsoft.Json.JsonProperty("LastLoginDateUtc", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime? LastLoginDateUtc
+        {
+            get { return _lastLoginDateUtc; }
+            set 
+            {
+                if (_lastLoginDateUtc != value)
+                {
+                    _lastLoginDateUtc = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
+    
+        [Newtonsoft.Json.JsonProperty("WelcomeEmailDateUtc", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public System.DateTime? WelcomeEmailDateUtc
+        {
+            get { return _welcomeEmailDateUtc; }
+            set 
+            {
+                if (_welcomeEmailDateUtc != value)
+                {
+                    _welcomeEmailDateUtc = value; 
+                    RaisePropertyChanged();
+                }
+            }
+        }
+    
         [Newtonsoft.Json.JsonProperty("McOrganisationUsers", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Collections.ObjectModel.ObservableCollection<McOrganisationUser> McOrganisationUsers
         {
@@ -2260,20 +2387,6 @@ namespace GovUk.Education.ManageCourses.ApiClient
                 if (_accessRequests != value)
                 {
                     _accessRequests = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("UserLogs", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.Collections.ObjectModel.ObservableCollection<UserLog> UserLogs
-        {
-            get { return _userLogs; }
-            set 
-            {
-                if (_userLogs != value)
-                {
-                    _userLogs = value; 
                     RaisePropertyChanged();
                 }
             }
@@ -2501,153 +2614,6 @@ namespace GovUk.Education.ManageCourses.ApiClient
         Completed = 2,
     
         Declined = 3,
-    
-    }
-    
-    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "9.10.50.0 (Newtonsoft.Json v9.0.0.0)")]
-    public partial class UserLog : System.ComponentModel.INotifyPropertyChanged
-    {
-        private int _id;
-        private System.DateTime _firstLoginDateUtc;
-        private int? _userId;
-        private McUser _user;
-        private string _userEmail;
-        private System.DateTime _lastLoginDateUtc;
-        private string _signInUserId;
-        private System.DateTime? _welcomeEmailDateUtc;
-    
-        [Newtonsoft.Json.JsonProperty("Id", Required = Newtonsoft.Json.Required.Always)]
-        public int Id
-        {
-            get { return _id; }
-            set 
-            {
-                if (_id != value)
-                {
-                    _id = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("FirstLoginDateUtc", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.DateTime FirstLoginDateUtc
-        {
-            get { return _firstLoginDateUtc; }
-            set 
-            {
-                if (_firstLoginDateUtc != value)
-                {
-                    _firstLoginDateUtc = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("UserId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public int? UserId
-        {
-            get { return _userId; }
-            set 
-            {
-                if (_userId != value)
-                {
-                    _userId = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("User", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public McUser User
-        {
-            get { return _user; }
-            set 
-            {
-                if (_user != value)
-                {
-                    _user = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("UserEmail", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string UserEmail
-        {
-            get { return _userEmail; }
-            set 
-            {
-                if (_userEmail != value)
-                {
-                    _userEmail = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("LastLoginDateUtc", Required = Newtonsoft.Json.Required.Always)]
-        [System.ComponentModel.DataAnnotations.Required]
-        public System.DateTime LastLoginDateUtc
-        {
-            get { return _lastLoginDateUtc; }
-            set 
-            {
-                if (_lastLoginDateUtc != value)
-                {
-                    _lastLoginDateUtc = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("SignInUserId", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public string SignInUserId
-        {
-            get { return _signInUserId; }
-            set 
-            {
-                if (_signInUserId != value)
-                {
-                    _signInUserId = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        [Newtonsoft.Json.JsonProperty("WelcomeEmailDateUtc", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public System.DateTime? WelcomeEmailDateUtc
-        {
-            get { return _welcomeEmailDateUtc; }
-            set 
-            {
-                if (_welcomeEmailDateUtc != value)
-                {
-                    _welcomeEmailDateUtc = value; 
-                    RaisePropertyChanged();
-                }
-            }
-        }
-    
-        public string ToJson() 
-        {
-            return Newtonsoft.Json.JsonConvert.SerializeObject(this);
-        }
-        
-        public static UserLog FromJson(string data)
-        {
-            return Newtonsoft.Json.JsonConvert.DeserializeObject<UserLog>(data);
-        }
-    
-        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-        
-        protected virtual void RaisePropertyChanged([System.Runtime.CompilerServices.CallerMemberName] string propertyName = null)
-        {
-            var handler = PropertyChanged;
-            if (handler != null) 
-                handler(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
-        }
     
     }
     

--- a/tests/ManageCourses.Tests/UnitTesting/InviteEmailModelTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/InviteEmailModelTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+using Moq;
+
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting
+{
+    [TestFixture]
+    public class InviteEmailModelTests
+    {
+        [Test]
+        public void Constructor_Test()
+        {
+            var user = new McUser()
+            {
+                Email = "actual email address",
+                FirstName = "FirstName  there are spaces at the end             "
+            };
+
+            var personalisation = new Dictionary<string, dynamic>() {
+                {"first_name", user.FirstName.Trim() } };
+
+            var model = new InviteEmailModel(user);
+
+            Assert.AreEqual(user.Email, model.EmailAddress);
+            CollectionAssert.AreEqual(personalisation, model.Personalisation);
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/InviteEmailServiceTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/InviteEmailServiceTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+
+using Moq;
+
+using GovUk.Education.ManageCourses.Api.Services.Email;
+using GovUk.Education.ManageCourses.Api.Services.Email.Config;
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting
+{
+    [TestFixture]
+    public class InviteEmailServiceTests
+    {
+        private IInviteEmailService Service = null;
+        private Mock<INotificationClientWrapper> mockNotificationClientWrapper = null;
+        private Mock<IInviteTemplateEmailConfig> mockInviteTemplateEmailConfig = null;
+
+        private string templateId = "mockInviteTemplateEmailConfig templateId";
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            mockNotificationClientWrapper = new Mock<INotificationClientWrapper>();
+            mockInviteTemplateEmailConfig = new Mock<IInviteTemplateEmailConfig>();
+
+            
+            mockInviteTemplateEmailConfig.Setup(x => x.TemplateId).Returns(templateId);
+
+            Service = new InviteEmailService(mockNotificationClientWrapper.Object, mockInviteTemplateEmailConfig.Object);
+        }
+
+        [Test]
+        public void Send()
+        {
+            var user = new McUser()
+            {
+                Email = "actual email address",
+                FirstName = "FirstName  there are spaces at the end             "
+            };
+
+            var personalisation = new Dictionary<string, dynamic>() {
+                {"first_name", user.FirstName.Trim() } };
+
+            var model = new InviteEmailModel(user);
+            Service.Send(model);
+
+            mockNotificationClientWrapper.Verify(x => x.SendEmail(user.Email, templateId, personalisation, null, null), Times.Once);
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/InviteTemplateEmailConfigTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/InviteTemplateEmailConfigTests.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+
+using Moq;
+
+using Microsoft.Extensions.Configuration;
+
+using GovUk.Education.ManageCourses.Api.Services.Email.Config;
+using GovUk.Education.ManageCourses.Api.Services.Email.Model;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting
+{
+    [TestFixture]
+    public class InviteTemplateEmailConfigTests
+    {
+        private string configId = "email:invite_template_id";
+        private string templateId = "invite_template_id";
+
+        [Test]
+        public void Constructor_Test()
+        {
+            var configMock = new Mock<IConfiguration>();
+
+            configMock.Setup(x => x[configId]).Returns(templateId);
+
+            var emailConfig = new InviteTemplateEmailConfig(configMock.Object);
+
+            Assert.AreEqual(configId, emailConfig.ConfigId);
+            Assert.AreEqual(templateId, emailConfig.TemplateId);
+            Assert.AreEqual(typeof(InviteEmailModel), emailConfig.Type);
+        }
+    }
+}


### PR DESCRIPTION
### Context
Invite template email functionality

### Changes proposed in this pull request
Added invite template email functionality

### Guidance to review
This just the invite email component, the actual mechanism to trigger for it is related to #70 & #71 

Requires `email:invite_template_id` to be configured refer to
https://dfedigital.atlassian.net/wiki/spaces/BaT/pages/389349377/Manage+Courses+API
