### PR TITLE
allow underscores in brachnames - underscores are not possible in semver

### DIFF
--- a/src/ManageCourses.ApiClient/ManageCourses.ApiClient.csproj
+++ b/src/ManageCourses.ApiClient/ManageCourses.ApiClient.csproj
@@ -38,8 +38,8 @@
       <PackageVersion>$(GitBaseVersion).$(GitSemVerPatch)</PackageVersion>
     </PropertyGroup>
     <PropertyGroup Condition="'$(GitBranch)'!='master'">
-      <Version>$(GitBaseVersion)-$(GitBranch).$(GitSemVerPatch)</Version>
-      <PackageVersion>$(GitBaseVersion)-$(GitBranch).$(GitSemVerPatch)</PackageVersion>
+      <Version>$(GitBaseVersion)-$([System.String]::Copy('$(GitBranch)').Replace('_','-')).$(GitSemVerPatch)</Version>
+      <PackageVersion>$(GitBaseVersion)-$([System.String]::Copy('$(GitBranch)').Replace('_','-')).$(GitSemVerPatch)</PackageVersion>
     </PropertyGroup>    
   </Target>
   <Target Name="NSwag" BeforeTargets="CoreCompile" DependsOnTargets="ResolveProjectReferences" Outputs="$(OutputSwaggerGeneration)">


### PR DESCRIPTION
### Context

Quick fix to unblock Martin

### Changes proposed in this pull request

Replace _ in branchname to -

### Guidance to review

Needs generalisation - any noncharacter string should be converted
