### PR TITLE
implemented string.Equals on getting organisation

### DIFF
--- a/src/ManageCourses.Api/Data/DataService.cs
+++ b/src/ManageCourses.Api/Data/DataService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ManageCourses.Api.Mapping;
 using GovUk.Education.ManageCourses.Api.Model;
@@ -313,7 +314,7 @@ namespace GovUk.Education.ManageCourses.Api.Data
              var ucasInstitution = mcOrganisationUsers.SelectMany(ou =>
                 ou.McOrganisationUsers.SelectMany(oi => oi.McOrganisation.McOrganisationInstitutions)).ToList();
 
-            var mcOrganisationInstitution = ucasInstitution.SingleOrDefault(oi => oi.UcasInstitution.InstCode == ucasCode);
+            var mcOrganisationInstitution = ucasInstitution.SingleOrDefault(oi => ucasCode.Equals(oi.UcasInstitution.InstCode, StringComparison.InvariantCultureIgnoreCase));
 
             if (mcOrganisationInstitution == null) return null;
 


### PR DESCRIPTION
### Context
No courses were returned after the url was made lowewr case
### Changes proposed in this pull request
Make the course search case insensitive
### Guidance to review
On line needed to be changed.
All other string compares are using strings (inst codes etc) that are taken from the data tables so do not need to be changed
