### PR TITLE
Reset smoke data

### DIFF
--- a/src/ManageCourses.Api/Program.cs
+++ b/src/ManageCourses.Api/Program.cs
@@ -9,17 +9,10 @@ namespace GovUk.Education.ManageCourses.Api
 {
     public class Program
     {
-        public static IConfiguration Configuration { get; } = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true)
-            .AddEnvironmentVariables()
-            .Build();
-
         public static int Main(string[] args)
         {
             Log.Logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(Configuration)
+                .ReadFrom.Configuration(LoggerConfiguration)
                 .CreateLogger();
 
             var programLogger = Log.ForContext<Program>();
@@ -50,5 +43,12 @@ namespace GovUk.Education.ManageCourses.Api
                 .UseStartup<Startup>()
                 .UseSerilog()
                 .Build();
+
+        private static IConfiguration LoggerConfiguration { get; } = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true)
+            .AddEnvironmentVariables()
+            .Build();
     }
 }

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -29,12 +29,11 @@ namespace GovUk.Education.ManageCourses.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            var connectionString = GetConnectionString(Configuration);
-
             services.AddEntityFrameworkNpgsql()
                 .AddDbContext<ManageCoursesDbContext>(
                     options => options.UseNpgsql(
-                        connectionString, b => b.MigrationsAssembly((typeof(ManageCoursesDbContext).Assembly).ToString())
+                        GetConnectionString(Configuration),
+                        b => b.MigrationsAssembly((typeof(ManageCoursesDbContext).Assembly).ToString())
                     )
                 );
 
@@ -118,11 +117,7 @@ namespace GovUk.Education.ManageCourses.Api
         /// Build a postgres connection string from configuration data
         /// </summary>
         /// <param name="config"></param>
-        /// <param name="dbNameSuffix">
-        ///     Optional. String to append to the database name, e.g. "test" to use "manage-test" as the database name.
-        ///     Intended to be used for building various test databases
-        /// </param>
-        public static string GetConnectionString(IConfiguration config, string dbNameSuffix = null)
+        public static string GetConnectionString(IConfiguration config)
         {
             var server = config["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
             var port = config["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
@@ -130,11 +125,6 @@ namespace GovUk.Education.ManageCourses.Api
             var user = config["PG_USERNAME"];
             var pword = config["PG_PASSWORD"];
             var dbase = config["PG_DATABASE"];
-
-            if (!string.IsNullOrWhiteSpace(dbNameSuffix))
-            {
-                dbase = $"{dbase}-{dbNameSuffix}";
-            }
 
             var sslDefault = "SSL Mode=Prefer;Trust Server Certificate=true";
             var ssl = config["PG_SSL"] ?? sslDefault;

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -122,7 +122,6 @@ namespace GovUk.Education.ManageCourses.Api
         ///     Optional. String to append to the database name, e.g. "test" to use "manage-test" as the database name.
         ///     Intended to be used for building various test databases
         /// </param>
-        /// <returns></returns>
         public static string GetConnectionString(IConfiguration config, string dbNameSuffix = null)
         {
             var server = config["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -113,7 +113,16 @@ namespace GovUk.Education.ManageCourses.Api
             app.UseMvc();
         }
 
-        public static string GetConnectionString(IConfiguration config)
+        /// <summary>
+        /// Build a postgres connection string from configuration data
+        /// </summary>
+        /// <param name="config"></param>
+        /// <param name="dbNameSuffix">
+        ///     Optional. String to append to the database name, e.g. "test" to use "manage-test" as the database name.
+        ///     Intended to be used for building various test databases
+        /// </param>
+        /// <returns></returns>
+        public static string GetConnectionString(IConfiguration config, string dbNameSuffix = null)
         {
             var server = config["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
             var port = config["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
@@ -121,6 +130,11 @@ namespace GovUk.Education.ManageCourses.Api
             var user = config["PG_USERNAME"];
             var pword = config["PG_PASSWORD"];
             var dbase = config["PG_DATABASE"];
+
+            if (!string.IsNullOrWhiteSpace(dbNameSuffix))
+            {
+                dbase = $"{dbase}-{dbNameSuffix}";
+            }
 
             var sslDefault = "SSL Mode=Prefer;Trust Server Certificate=true";
             var ssl = config["PG_SSL"] ?? sslDefault;

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -61,7 +61,8 @@ namespace GovUk.Education.ManageCourses.Api
             services.AddScoped<IInviteTemplateEmailConfig, InviteTemplateEmailConfig>();
             services.AddScoped<IInviteEmailService, InviteEmailService>();
 
-            services.AddScoped<IAccessRequestService>(provider => {
+            services.AddScoped<IAccessRequestService>(provider =>
+            {
                 return new AccessRequestService(provider.GetService<IManageCoursesDbContext>(),
                  new EmailServiceFactory(Configuration["email:api_key"])
                  .MakeAccessRequestEmailService(

--- a/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
@@ -14,9 +14,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.DatabaseAccess
     /// </summary>
     public class DbIntegrationTestBase
     {
-        protected ManageCoursesDbContext context;
-
-        protected IList<EntityEntry> entitiesToCleanUp = new List<EntityEntry>();
+        protected ManageCoursesDbContext Context;
+        protected IList<EntityEntry> EntitiesToCleanUp = new List<EntityEntry>();
 
         protected ManageCoursesDbContext GetContext()
         {
@@ -27,36 +26,36 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.DatabaseAccess
         [OneTimeSetUp]
         public void SetUpFixture()
         {
-            context = GetContext();
-            context.Database.EnsureDeleted();
-            context.Database.Migrate();
+            Context = GetContext();
+            Context.Database.EnsureDeleted();
+            Context.Database.Migrate();
         }
 
         [SetUp]
         public void SetUp()
         {
-            context = GetContext();
+            Context = GetContext();
         }
 
         [TearDown]
         public virtual void TearDown()
         {
-            if (entitiesToCleanUp.Any())
+            if (EntitiesToCleanUp.Any())
             {
-                foreach (var e in entitiesToCleanUp)
+                foreach (var e in EntitiesToCleanUp)
                 {
                     e.State = EntityState.Deleted;
                 }
-                entitiesToCleanUp.Clear();
-                context.SaveChanges();
+                EntitiesToCleanUp.Clear();
+                Context.SaveChanges();
             }
         }
 
         [OneTimeTearDown]
         public void TearDownFixture()
         {
-            context = GetContext();
-            context.Database.EnsureDeleted();
+            Context = GetContext();
+            Context.Database.EnsureDeleted();
         }
     }
 }

--- a/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.DatabaseAccess
         protected ManageCoursesDbContext GetContext()
         {
             var config = TestConfigBuilder.BuildTestConfig();
-            return ContextLoader.GetDbContext(config, "integration");
+            return ContextLoader.GetDbContext(config, "dbintegration");
         }
 
         [OneTimeSetUp]

--- a/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
@@ -20,7 +20,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.DatabaseAccess
         protected ManageCoursesDbContext GetContext()
         {
             var config = TestConfigBuilder.BuildTestConfig();
-            return ContextLoader.GetDbContext(config, "dbintegration");
+            config["PG_DATABASE"] += "-dbintegration";
+            return ContextLoader.GetDbContext(config);
         }
 
         [OneTimeSetUp]

--- a/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
@@ -20,7 +20,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.DatabaseAccess
 
         protected ManageCoursesDbContext GetContext()
         {
-            return ContextLoader.GetDbContext(ContextLoader.IntegrationTestJson);
+            var config = TestConfigBuilder.BuildTestConfig();
+            return ContextLoader.GetDbContext(config, "integration");
         }
 
         [OneTimeSetUp]

--- a/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DatabaseAccess/DbIntegrationTestBase.cs
@@ -51,12 +51,5 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.DatabaseAccess
                 Context.SaveChanges();
             }
         }
-
-        [OneTimeTearDown]
-        public void TearDownFixture()
-        {
-            Context = GetContext();
-            Context.Database.EnsureDeleted();
-        }
     }
 }

--- a/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
@@ -41,24 +41,24 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 LastName = "Sinatra",
                 Email = "frank@example.org",
             };
-            context.AddMcUser(_testUserBob);
-            context.AddMcUser(_userTestUserFrank);
-            context.SaveChanges();
+            Context.AddMcUser(_testUserBob);
+            Context.AddMcUser(_userTestUserFrank);
+            Context.SaveChanges();
 
             _mockWelcomeEmailService = new Mock<IWelcomeEmailService>();
 
             var mockClock = new Mock<IClock>();
             mockClock.SetupGet(c => c.UtcNow).Returns(() => _mockTime);
 
-            _userService = new UserService(context, _mockWelcomeEmailService.Object, mockClock.Object);
+            _userService = new UserService(Context, _mockWelcomeEmailService.Object, mockClock.Object);
         }
 
         [TearDown]
         public void Cleanup()
         {
-            context.Remove(_testUserBob);
-            context.Remove(_userTestUserFrank);
-            context.Save();
+            Context.Remove(_testUserBob);
+            Context.Remove(_userTestUserFrank);
+            Context.Save();
         }
 
         [Test]

--- a/tests/ManageCourses.Tests/ManageCourses.Tests.csproj
+++ b/tests/ManageCourses.Tests/ManageCourses.Tests.csproj
@@ -27,7 +27,6 @@
     <None Update="logger.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="integration-tests.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.2" />

--- a/tests/ManageCourses.Tests/README.md
+++ b/tests/ManageCourses.Tests/README.md
@@ -1,0 +1,24 @@
+﻿# Tests
+
+## Smoke
+
+These test the API HTTP endpoints with a real client, with the API running in a
+captive web host.
+
+There shouldn't be too many of these as they are slow, but the should test the
+major paths through the API to give confidence everything is connected
+properly, (e.g. is the dependency injection wired up and the database
+connected).
+
+## DbIntegration
+
+These test a class (usually a "service" class) against a real database. This
+tests the fragile boundary across EF and real SQL.
+
+There should be more of these, but they are still fairly expensive.
+
+## Unit
+
+These test classes in isolation. As much as possible should be pushed down to
+these, leaving just enough smoke & integration tests to give confidence in the
+whole system.

--- a/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
@@ -19,25 +19,25 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [Test]
         public void DataExport_WithEmptyCampus()
         {
-            var dfeSignInConfig = config.GetSection("credentials").GetSection("dfesignin");
+            var dfeSignInConfig = Config.GetSection("credentials").GetSection("dfesignin");
 
             var communicator = new DfeSignInCommunicator(dfeSignInConfig["host"], dfeSignInConfig["redirect_host"], dfeSignInConfig["clientid"], dfeSignInConfig["clientsecret"]);
             var accessToken = communicator.GetAccessTokenAsync(dfeSignInConfig["username"], dfeSignInConfig["password"]).Result;
 
 
             var httpClient = new HttpClient();
-            var apiKeyAccessToken = config["api:key"];
+            var apiKeyAccessToken = Config["api:key"];
 
 
             var clientImport = new ManageCoursesApiClient(new MockApiClientConfiguration(apiKeyAccessToken), httpClient);
-            clientImport.BaseUrl = localWebHost.Address;
+            clientImport.BaseUrl = LocalWebHost.Address;
 
             clientImport.Data_ImportReferenceDataAsync(TestPayloadBuilder.MakeReferenceDataPayload(dfeSignInConfig["username"])).Wait();
             clientImport.Data_ImportAsync(TestPayloadBuilder.MakeSimpleUcasPayload()).Wait();
 
 
             var clientExport = new ManageCoursesApiClient(new MockApiClientConfiguration(accessToken), httpClient);
-            clientExport.BaseUrl = localWebHost.Address;
+            clientExport.BaseUrl = LocalWebHost.Address;
 
             var export = clientExport.Data_ExportByOrganisationAsync("ABC").Result;
 
@@ -72,7 +72,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var httpClient = new HttpClient();
 
             var client = new ManageCoursesApiClient(new MockApiClientConfiguration(accessToken), httpClient);
-            client.BaseUrl = localWebHost.Address;
+            client.BaseUrl = LocalWebHost.Address;
 
 
             Assert.That(() => client.Data_ExportByOrganisationAsync("ABC"),
@@ -88,19 +88,19 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [Test]
         public async Task Invite()
         {
-            var accessToken = config["api:key"];
+            var accessToken = Config["api:key"];
 
             var httpClient = new HttpClient();
 
             var client = new ManageCoursesApiClient(new MockApiClientConfiguration(accessToken), httpClient);
-            client.BaseUrl = localWebHost.Address;
+            client.BaseUrl = LocalWebHost.Address;
 
             var result = await client.Invite_IndexAsync();
 
             Assert.AreEqual(200, result.StatusCode);
 
             var client2 = new ManageCoursesApiClient(new MockApiClientConfiguration("accessToken"), httpClient);
-            client2.BaseUrl = localWebHost.Address;
+            client2.BaseUrl = LocalWebHost.Address;
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var httpClient = new HttpClient();
 
             var client = new ManageCoursesApiClient(new MockApiClientConfiguration(accessToken), httpClient);
-            client.BaseUrl = localWebHost.Address;
+            client.BaseUrl = LocalWebHost.Address;
 
 
             Assert.That(() => client.Invite_IndexAsync(),
@@ -127,7 +127,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var httpClient = new HttpClient();
 
             var client = new ManageCoursesApiClient(new MockApiClientConfiguration(accessToken), httpClient);
-            client.BaseUrl = localWebHost.Address;
+            client.BaseUrl = LocalWebHost.Address;
 
             Assert.That(() => client.Invite_IndexAsync(),
                 Throws.TypeOf<SwaggerException>()

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -28,7 +28,9 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 
         private ManageCoursesDbContext GetContext()
         {
-            var context = ContextLoader.GetDbContext(config, "smoke");
+            // Note this has to be the *same* database as the one that the captive api host will have configured using its own
+            // view of the configuration.
+            var context = ContextLoader.GetDbContext(config);
             return context;
         }
 

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -27,8 +27,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 
         private ManageCoursesDbContext GetContext()
         {
-            // Note this has to be the *same* database as the one that the captive api host will have configured using its own
-            // view of the configuration.
+            Config["PG_DATABASE"] += "-smoke";
             var context = ContextLoader.GetDbContext(Config);
             return context;
         }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -39,9 +39,6 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             {
                 LocalWebHost.Stop();
             }
-
-            var context = GetContext();
-            context.Database.EnsureDeleted();
         }
     }
 }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -1,4 +1,4 @@
-using System.IO;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using GovUk.Education.ManageCourses.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -18,12 +18,18 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 
             config = TestConfigBuilder.BuildTestConfig();
 
-            var context = ContextLoader.GetDbContext(config, "smoke");
+            var context = GetContext();
 
             context.Database.EnsureDeleted();
             context.Database.Migrate();
 
             localWebHost = new ApiLocalWebHost(config).Launch();
+        }
+
+        private ManageCoursesDbContext GetContext()
+        {
+            var context = ContextLoader.GetDbContext(config, "smoke");
+            return context;
         }
 
         [OneTimeTearDown]
@@ -33,6 +39,9 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             {
                 localWebHost.Stop();
             }
+
+            var context = GetContext();
+            context.Database.EnsureDeleted();
         }
     }
 }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -8,9 +8,9 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 {
     public abstract class ApiSmokeTestBase
     {
-        protected ApiLocalWebHost localWebHost = null;
+        protected ApiLocalWebHost localWebHost;
 
-        protected IConfiguration config = null;
+        protected IConfiguration config;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 {
     public class ApiSmokeTestBase
-    {        
+    {
         protected ApiLocalWebHost localWebHost = null;
 
         protected IConfiguration config = null;
@@ -15,17 +15,13 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            var context = ContextLoader.GetDbContext(ContextLoader.IntegrationTestJson);
+
+            config = TestConfigBuilder.BuildTestConfig();
+
+            var context = ContextLoader.GetDbContext(config, "smoke");
 
             context.Database.EnsureDeleted();
             context.Database.Migrate();
-
-            config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile(ContextLoader.IntegrationTestJson)
-                .AddUserSecrets<ApiEndpointTests>()
-                .AddEnvironmentVariables()
-                .Build();
 
             localWebHost = new ApiLocalWebHost(config).Launch();
         }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -8,38 +8,37 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 {
     public abstract class ApiSmokeTestBase
     {
-        protected ApiLocalWebHost localWebHost;
-
-        protected IConfiguration config;
+        protected ApiLocalWebHost LocalWebHost;
+        protected IConfiguration Config;
 
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
 
-            config = TestConfigBuilder.BuildTestConfig();
+            Config = TestConfigBuilder.BuildTestConfig();
 
             var context = GetContext();
 
             context.Database.EnsureDeleted();
             context.Database.Migrate();
 
-            localWebHost = new ApiLocalWebHost(config).Launch();
+            LocalWebHost = new ApiLocalWebHost(Config).Launch();
         }
 
         private ManageCoursesDbContext GetContext()
         {
             // Note this has to be the *same* database as the one that the captive api host will have configured using its own
             // view of the configuration.
-            var context = ContextLoader.GetDbContext(config);
+            var context = ContextLoader.GetDbContext(Config);
             return context;
         }
 
         [OneTimeTearDown]
         public void OneTimeTearDown()
         {
-            if (localWebHost != null)
+            if (LocalWebHost != null)
             {
-                localWebHost.Stop();
+                LocalWebHost.Stop();
             }
 
             var context = GetContext();

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 {
-    public class ApiSmokeTestBase
+    public abstract class ApiSmokeTestBase
     {
         protected ApiLocalWebHost localWebHost = null;
 

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using GovUk.Education.ManageCourses.Tests.TestUtilities;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using NUnit.Framework;
 
@@ -14,9 +15,14 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            var context = ContextLoader.GetDbContext(ContextLoader.IntegrationTestJson);
+
+            context.Database.EnsureDeleted();
+            context.Database.Migrate();
+
             config = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("integration-tests.json")
+                .AddJsonFile(ContextLoader.IntegrationTestJson)
                 .AddUserSecrets<ApiEndpointTests>()
                 .AddEnvironmentVariables()
                 .Build();

--- a/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
@@ -10,12 +10,12 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
         /// <summary>
         /// Configures and returns a manage-courses dbContext
         /// </summary>
-        /// <param name="config"></param>
-        /// <param name="dbNameSuffix">Database name suffix to separate different test types into different databases</param>
-        public static ManageCoursesDbContext GetDbContext(IConfiguration config, string dbNameSuffix = null)
+        public static ManageCoursesDbContext GetDbContext(IConfiguration config)
         {
             var options = new DbContextOptionsBuilder<ManageCoursesDbContext>()
-                .UseNpgsql(Startup.GetConnectionString(config, dbNameSuffix))
+                .UseNpgsql(
+                        Startup.GetConnectionString(config)
+                    )
                 .Options;
 
             return new ManageCoursesDbContext(options);

--- a/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using GovUk.Education.ManageCourses.Api;
+﻿using GovUk.Education.ManageCourses.Api;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -8,21 +7,15 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
 {
     internal class ContextLoader
     {
-        public const string IntegrationTestJson = "integration-tests.json";
-
         /// <summary>
         /// Configures and returns a manage-courses dbContext
         /// </summary>
-        /// <param name="configFilename">name of json file to use for config data</param>
-        public static ManageCoursesDbContext GetDbContext(string configFilename)
+        /// <param name="config"></param>
+        /// <param name="dbNameSuffix">Database name suffix to separate different test types into different databases</param>
+        public static ManageCoursesDbContext GetDbContext(IConfiguration config, string dbNameSuffix)
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile(configFilename)
-                .Build();
-
             var options = new DbContextOptionsBuilder<ManageCoursesDbContext>()
-                .UseNpgsql(Startup.GetConnectionString(config))
+                .UseNpgsql(Startup.GetConnectionString(config, dbNameSuffix))
                 .Options;
 
             return new ManageCoursesDbContext(options);

--- a/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
@@ -12,7 +12,7 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
         /// </summary>
         /// <param name="config"></param>
         /// <param name="dbNameSuffix">Database name suffix to separate different test types into different databases</param>
-        public static ManageCoursesDbContext GetDbContext(IConfiguration config, string dbNameSuffix)
+        public static ManageCoursesDbContext GetDbContext(IConfiguration config, string dbNameSuffix = null)
         {
             var options = new DbContextOptionsBuilder<ManageCoursesDbContext>()
                 .UseNpgsql(Startup.GetConnectionString(config, dbNameSuffix))

--- a/tests/ManageCourses.Tests/TestUtilities/TestConfigBuilder.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/TestConfigBuilder.cs
@@ -1,0 +1,20 @@
+﻿using System.IO;
+using GovUk.Education.ManageCourses.Tests.SmokeTests;
+using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.ManageCourses.Tests.TestUtilities
+{
+    internal class TestConfigBuilder
+    {
+        public static IConfigurationRoot BuildTestConfig()
+        {
+            var config = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddUserSecrets<ApiEndpointTests>()
+            .AddEnvironmentVariables()
+            .Build();
+
+            return config;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/integration-tests.json
+++ b/tests/ManageCourses.Tests/integration-tests.json
@@ -1,7 +1,0 @@
-﻿{
-  "MANAGE_COURSES_POSTGRESQL_SERVICE_HOST": "localhost",
-  "MANAGE_COURSES_POSTGRESQL_SERVICE_PORT": "5432",
-  "PG_DATABASE": "manage-test",
-  "PG_USERNAME": "postgres",
-  "PG_PASSWORD": "postgres"
-}


### PR DESCRIPTION
### Context

Smoke test `ApiEndpointTests.DataExport_WithEmptyCampus` would fail if run individually after other test runs because there was no cleanup of the data.

This PR adds cleanup before & after each smoke test run, fixing the flapping test.

### Changes proposed in this pull request

* Remove hard-coded username/password etc, rely on single user-secrets for all db config (test + captured host)
* Code cleanup
* New readme for context on tests

