### PR TITLE
Extract static GetConnectionString() from Startup.cs

### DIFF
--- a/src/ManageCourses.Api/McConfig.cs
+++ b/src/ManageCourses.Api/McConfig.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.ManageCourses.Api
+{
+    public class McConfig
+    {
+        private readonly IConfiguration _configuration;
+
+        public McConfig(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        /// <summary>
+        /// Build a postgres connection string from configuration data
+        /// </summary>
+        public string BuildConnectionString()
+        {
+            var server = _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
+            var port = _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
+
+            var user = _configuration["PG_USERNAME"];
+            var pword = _configuration["PG_PASSWORD"];
+            var dbase = _configuration["PG_DATABASE"];
+
+            var sslDefault = "SSL Mode=Prefer;Trust Server Certificate=true";
+            var ssl = _configuration["PG_SSL"] ?? sslDefault;
+
+            var connectionString = $"Server={server};Port={port};Database={dbase};User Id={user};Password={pword};{ssl}";
+            return connectionString;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -29,13 +29,17 @@ namespace GovUk.Education.ManageCourses.Api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            var mcConfig = new McConfig(Configuration);
+            var connectionString = mcConfig.BuildConnectionString();
+
             services.AddEntityFrameworkNpgsql()
                 .AddDbContext<ManageCoursesDbContext>(
-                    options => options.UseNpgsql(
-                        GetConnectionString(Configuration),
-                        b => b.MigrationsAssembly((typeof(ManageCoursesDbContext).Assembly).ToString())
-                    )
-                );
+                    options =>
+                    {
+                        options.UseNpgsql(connectionString,
+                            b => b.MigrationsAssembly((typeof(ManageCoursesDbContext).Assembly).ToString())
+                        );
+                    });
 
             services.AddScoped<IManageCoursesDbContext>(provider => provider.GetService<ManageCoursesDbContext>());
 
@@ -112,26 +116,6 @@ namespace GovUk.Education.ManageCourses.Api
 
             app.UseAuthentication();
             app.UseMvc();
-        }
-
-        /// <summary>
-        /// Build a postgres connection string from configuration data
-        /// </summary>
-        /// <param name="config"></param>
-        public static string GetConnectionString(IConfiguration config)
-        {
-            var server = config["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
-            var port = config["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
-
-            var user = config["PG_USERNAME"];
-            var pword = config["PG_PASSWORD"];
-            var dbase = config["PG_DATABASE"];
-
-            var sslDefault = "SSL Mode=Prefer;Trust Server Certificate=true";
-            var ssl = config["PG_SSL"] ?? sslDefault;
-
-            var connectionString = $"Server={server};Port={port};Database={dbase};User Id={user};Password={pword};{ssl}";
-            return connectionString;
         }
     }
 }

--- a/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
@@ -12,10 +12,11 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
         /// </summary>
         public static ManageCoursesDbContext GetDbContext(IConfiguration config)
         {
+            var mcConfig = new McConfig(config);
+            var connectionString = mcConfig.BuildConnectionString();
+
             var options = new DbContextOptionsBuilder<ManageCoursesDbContext>()
-                .UseNpgsql(
-                        Startup.GetConnectionString(config)
-                    )
+                .UseNpgsql(connectionString)
                 .Options;
 
             return new ManageCoursesDbContext(options);


### PR DESCRIPTION
### Context

Improves on a code smell. Pure refactor.

### Changes proposed in this pull request

* Move `BuildConnectionString()` out of `Startup` class
