### PR TITLE
Return 422 if invited user doesn't exist

### DIFF
--- a/src/ManageCourses.Api/Controllers/InviteController.cs
+++ b/src/ManageCourses.Api/Controllers/InviteController.cs
@@ -1,3 +1,4 @@
+using GovUk.Education.ManageCourses.Api.Exceptions;
 using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -20,8 +21,17 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         [HttpPost]
         public IActionResult Index(string email)
         {
-            _inviteService.Invite(email);
-            return this.Ok();
+            try
+            {
+                _inviteService.Invite(email);
+                return Ok();
+            }
+            catch (McUserNotFoundException)
+            {
+                // Using 422 because: https://stackoverflow.com/questions/3050518/what-http-status-response-code-should-i-use-if-the-request-is-missing-a-required/10323055#10323055
+                Response.StatusCode = 422; // unprocessable entity (extension to http)
+                return Json(new { error = "McUser not found" });
+            }
         }
     }
 }


### PR DESCRIPTION
### Context

API was returning 500 server error for unknown users, which is indistinguishable from any other failure.
