### PR TITLE
Test setup overrides

### DIFF
--- a/tests/ManageCourses.Tests/DbIntegration/AccessRequestServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/AccessRequestServiceTests.cs
@@ -17,8 +17,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         private AccessRequestService System;
         private MockEmailService EmailService;
 
-        [SetUp]
-        public void Setup()
+        protected override void Setup()
         {
             Context.AccessRequests.RemoveRange(Context.AccessRequests);
 

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -23,8 +23,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         private const string TestUserEmail_3 = "email_3@test-manage-courses.gov.uk";
 
 
-        [SetUp]
-        public void Setup()
+        protected override void Setup()
         {
             Context.UcasCourses.RemoveRange(Context.UcasCourses);
             Context.CourseCodes.RemoveRange(Context.CourseCodes);

--- a/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
@@ -16,13 +16,20 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         protected IConfigurationRoot Config;
 
         [OneTimeSetUp]
-        public virtual void OneTimeSetUp()
+        public virtual void BaseOneTimeSetUp()
         {
             Config = TestConfigBuilder.BuildTestConfig();
             Context = ContextLoader.GetDbContext(Config);
             Context.Database.EnsureDeleted();
             Context.Database.Migrate();
+            OneTimeSetup();
         }
+
+        /// <summary>
+        /// Optionally override this in derived test classes to do any fixture-specific setup.
+        /// This will be run once the database has been reset and migrated.
+        /// </summary>
+        public virtual void OneTimeSetup() { }
 
         [SetUp]
         public void SetUp()

--- a/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
@@ -32,7 +32,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         public virtual void OneTimeSetup() { }
 
         [SetUp]
-        public void SetUp()
+        public void BaseSetup()
         {
             // get a fresh context every time to avoid stale in-memory data contaminating subsequent tests
             Context = ContextLoader.GetDbContext(Config);
@@ -50,6 +50,14 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                    );
                 END
                 $func$;").Wait();
+            Setup();
         }
+
+        /// <summary>
+        /// Optionally override this in derived test classes to do any test-specific setup.
+        /// This will be run once the database cleared of any stale data from previous tests
+        /// and a fresh <see cref="Context"/> obtained.
+        /// </summary>
+        protected virtual void Setup() { }
     }
 }

--- a/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
@@ -25,8 +25,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         private McUser _testUserBob;
         private McUser _userTestUserFrank;
 
-        [SetUp]
-        public void Setup()
+        protected override void Setup()
         {
             _testUserBob = new McUser
             {

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -8,11 +8,8 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
     {
         protected ApiLocalWebHost LocalWebHost;
 
-        [OneTimeSetUp]
-        public override void OneTimeSetUp()
+        public override void OneTimeSetup()
         {
-            base.OneTimeSetUp();
-
             LocalWebHost = new ApiLocalWebHost(Config).Launch();
         }
 


### PR DESCRIPTION
### Context

Use of attributes on multiple levels of inheritance is unclear in expected order of execution and interaction.

I want to use this for the new tests for enrichment that are in progress.

### Changes proposed in this pull request

Only use attributes on base classes. Call virtual method in all derived test classes.