### PR TITLE
Refactor DataExport_WithEmptyCampus

### DIFF
--- a/tests/ManageCourses.Tests/SmokeTests/MockApiClientConfiguration.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/MockApiClientConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.ApiClient;
+
+namespace GovUk.Education.ManageCourses.Tests.SmokeTests
+{
+    public partial class ApiEndpointTests
+    {
+        private class MockApiClientConfiguration : IManageCoursesApiClientConfiguration
+        {
+            private readonly string _accessToken;
+
+            public MockApiClientConfiguration(string accessToken)
+            {
+                _accessToken = accessToken;
+            }
+
+            public Task<string> GetAccessTokenAsync()
+            {
+                return Task.FromResult(_accessToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This will allow re-use of the logic to build test clients for both the api-key protected endpoints
and the DfE Sign-in (OAuth) protected endpoints
