### PR TITLE
Institution-wise import

### DIFF
--- a/src/ManageCourses.Api/Services/Data/DataService.cs
+++ b/src/ManageCourses.Api/Services/Data/DataService.cs
@@ -34,6 +34,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Data
         {
             var allInstitutions = _context.UcasInstitutions.ToList();
             
+            _logger.LogWarning("Beginning UCAS import");
             _logger.LogInformation($"Upserting {allInstitutions.Count()} institutions");
             int processed = 0;
             foreach (var inst in allInstitutions)
@@ -48,7 +49,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Data
                 }
                 if(++processed % 100 == 0) 
                 {
-                    _logger.LogInformation($"Upserted ${processed} institutions so far");
+                    _logger.LogInformation($"Upserted {processed} institutions so far");
                 }            
             }
             _logger.LogWarning("Completed UCAS import");  
@@ -203,41 +204,6 @@ namespace GovUk.Education.ManageCourses.Api.Services.Data
                 );
             }
             return payload;
-        }
-
-        private UcasPayload DeleteCampus(UcasCampus campus)
-        {
-            var toDelete = new UcasPayload() 
-            {
-                Campuses = _context.UcasCampuses.Where(c => c.CampusCode == campus.CampusCode && c.InstCode == campus.InstCode)
-            };
-            _context.UcasCampuses.RemoveRange(toDelete.Campuses);
-            return toDelete;
-        }
-
-        private UcasPayload AddCampus(UcasCampus campus)
-        {
-            _context.AddUcasCampus(
-                new UcasCampus
-                {
-                    InstCode = campus.InstCode,
-                    CampusCode = campus.CampusCode,
-                    CampusName = campus.CampusName,
-                    Addr1 = campus.Addr1,
-                    Addr2 = campus.Addr2,
-                    Addr3 = campus.Addr3,
-                    Addr4 = campus.Addr4,
-                    Postcode = campus.Postcode,
-                    TelNo = campus.TelNo,
-                    Email = campus.Email,
-                    RegionCode = campus.RegionCode
-                }
-            );      
-
-            return new UcasPayload()
-            {
-                Campuses = new List<UcasCampus>{campus}
-            };      
         }
         
         public UserOrganisation GetOrganisationForUser(string email, string instCode)

--- a/src/ManageCourses.Domain/EqualityComparers/UcasCampusEquivalencyComparer.cs
+++ b/src/ManageCourses.Domain/EqualityComparers/UcasCampusEquivalencyComparer.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Domain.EqualityComparers
+{
+    public class UcasCampusEquivalencyComparer : IEqualityComparer<UcasCampus>
+    {
+        public bool Equals(UcasCampus x, UcasCampus y)
+        {
+            return (x != null ^ y != null) && string.Equals(x.CampusCode, y.CampusCode) && string.Equals(x.InstCode, y.InstCode); 
+        }
+
+        public int GetHashCode(UcasCampus obj)
+        {
+            if (obj == null) return 0;
+
+            int result = (obj.InstCode == null ? obj.InstCode.GetHashCode() : 0);
+            result = (result * 397) ^ (obj.CampusCode == null ? obj.CampusCode.GetHashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/src/ManageCourses.Domain/EqualityComparers/UcasCampusEquivalencyComparer.cs
+++ b/src/ManageCourses.Domain/EqualityComparers/UcasCampusEquivalencyComparer.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ManageCourses.Domain.EqualityComparers
     {
         public bool Equals(UcasCampus x, UcasCampus y)
         {
-            return (x != null ^ y != null) && string.Equals(x.CampusCode, y.CampusCode) && string.Equals(x.InstCode, y.InstCode); 
+            return x != null && y != null && string.Equals(x.CampusCode, y.CampusCode) && string.Equals(x.InstCode, y.InstCode); 
         }
 
         public int GetHashCode(UcasCampus obj)

--- a/src/ManageCourses.Domain/EqualityComparers/UcasCourseEquivalencyComparer.cs
+++ b/src/ManageCourses.Domain/EqualityComparers/UcasCourseEquivalencyComparer.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Domain.EqualityComparers
+{
+    public class CourseCodeEquivalencyComparer : IEqualityComparer<CourseCode>
+    {
+        public bool Equals(CourseCode x, CourseCode y)
+        {
+            return (x != null ^ y != null) && string.Equals(x.CrseCode, y.CrseCode) && string.Equals(x.InstCode, y.InstCode); 
+        }
+
+        public int GetHashCode(CourseCode obj)
+        {
+            if (obj == null) return 0;
+
+            int result = (obj.InstCode == null ? obj.InstCode.GetHashCode() : 0);
+            result = (result * 397) ^ (obj.CrseCode == null ? obj.CrseCode.GetHashCode() : 0);
+            return result;
+        }
+    }
+}

--- a/src/ManageCourses.Domain/EqualityComparers/UcasCourseEquivalencyComparer.cs
+++ b/src/ManageCourses.Domain/EqualityComparers/UcasCourseEquivalencyComparer.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ManageCourses.Domain.EqualityComparers
     {
         public bool Equals(CourseCode x, CourseCode y)
         {
-            return (x != null ^ y != null) && string.Equals(x.CrseCode, y.CrseCode) && string.Equals(x.InstCode, y.InstCode); 
+            return x != null && y != null && string.Equals(x.CrseCode, y.CrseCode) && string.Equals(x.InstCode, y.InstCode); 
         }
 
         public int GetHashCode(CourseCode obj)

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -24,6 +24,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         private const string TestUserEmail1 = "email_1@test-manage-courses.gov.uk";
         private const string TestUserEmail2 = "email_2@test-manage-courses.gov.uk";
         private const string TestUserEmail3 = "email_3@test-manage-courses.gov.uk";
+        private const string OrgId1 = "OrgId_1";
 
         protected override void Setup()
         {
@@ -71,7 +72,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
 
             GetCoursesForUser_isNull(TestUserEmail1, null);
             GetCoursesForUser_isNull(TestUserEmail2, null);
-            GetCoursesForUser_isNull(TestUserEmail3, "OrgId_1");
+            GetCoursesForUser_isNull(TestUserEmail3, OrgId1);
         }
 
         [Test]
@@ -378,31 +379,33 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     Email = TestUserEmail3
                 }
             };
+            const string orgId2 = "OrgId_2";
             var organisations = new List<McOrganisation> {
                 new McOrganisation {
-                    OrgId = "OrgId_1"
+                    OrgId = OrgId1
                 },
                 new McOrganisation {
-                    OrgId = "OrgId_2"
+                    OrgId = orgId2
                 }
 
             };
 
+            const string instCode2 = "InstCode_2";
             var institutions = new List<UcasInstitution>
             {
                 new UcasInstitution {
                     InstCode = InstCode1
                 },
                 new UcasInstitution {
-                    InstCode = "InstCode_2"
+                    InstCode = instCode2
                 }
             };
 
             var organisationInstitutions = new List<McOrganisationInstitution>
             {
                 new McOrganisationInstitution {
-                    InstitutionCode = institutions[1].InstCode,
-                    OrgId = organisations[1].OrgId
+                    InstitutionCode = instCode2,
+                    OrgId = orgId2,
                 }
             };
             var organisationUsers = new List<McOrganisationUser>
@@ -412,7 +415,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 },
                 new McOrganisationUser {
                     Email = TestUserEmail3,
-                    OrgId = "OrgId_1"
+                    OrgId = OrgId1
                 }
             };
             var result = new ReferenceDataPayload

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -182,92 +182,6 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             Assert.AreEqual("The best title", Context.UcasCourses.Single().CrseTitle);
         }
 
-        public ReferenceDataPayload GetUserPayload()
-        {
-            var users = new List<McUser>
-            {
-                new McUser
-                {
-                    FirstName = "FirstName_1",
-                    LastName = "LastName_1",
-                    Email = TestUserEmail1
-                },
-                new McUser
-                {
-                    FirstName = "FirstName_2",
-                    LastName = "LastName_2",
-                    Email = TestUserEmail2
-                },
-                new McUser
-                {
-                    FirstName = "FirstName_3",
-                    LastName = "LastName_3",
-                    Email = TestUserEmail3
-                }
-            };
-            var organisations = new List<McOrganisation> {
-                new McOrganisation {
-                    OrgId = "OrgId_1"
-                },
-                new McOrganisation {
-                    OrgId = "OrgId_2"
-                }
-
-            };
-
-            var institutions = new List<UcasInstitution>
-            {
-                new UcasInstitution {
-                    InstCode = "InstCode_1"
-                },
-                new UcasInstitution {
-                    InstCode = "InstCode_2"
-                }
-            };
-
-            var organisationInstitutions = new List<McOrganisationInstitution>
-            {
-                new McOrganisationInstitution {
-                    InstitutionCode = institutions[1].InstCode,
-                    OrgId = organisations[1].OrgId
-                }
-            };
-            var organisationUsers = new List<McOrganisationUser>
-            {
-                new McOrganisationUser {
-                    Email = TestUserEmail2,
-                },
-                new McOrganisationUser {
-                    Email = TestUserEmail3,
-                    OrgId = "OrgId_1"
-                }
-            };
-            var result = new ReferenceDataPayload
-            {
-                Users = users,
-                OrganisationInstitutions = organisationInstitutions,
-                OrganisationUsers = organisationUsers,
-                Organisations = organisations,
-                Institutions = institutions
-            };
-
-            return result;
-        }
-
-        public UcasPayload GetUcasPayload()
-        {
-            return new UcasPayload
-            {
-                Courses = new List<UcasCourse>{
-                    new UcasCourse
-                    {
-                        InstCode = "InstCode_1",
-                        CrseCode = "CourseCode_1"
-                    }
-                }
-            };
-        }
-
         [TestCase("nothing@nowhere.com", null)]
         public void GetCoursesForUser_isNull(string email, string orgId)
         {
@@ -445,6 +359,91 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             }
         }
 
+        private static ReferenceDataPayload GetUserPayload()
+        {
+            var users = new List<McUser>
+            {
+                new McUser
+                {
+                    FirstName = "FirstName_1",
+                    LastName = "LastName_1",
+                    Email = TestUserEmail1
+                },
+                new McUser
+                {
+                    FirstName = "FirstName_2",
+                    LastName = "LastName_2",
+                    Email = TestUserEmail2
+                },
+                new McUser
+                {
+                    FirstName = "FirstName_3",
+                    LastName = "LastName_3",
+                    Email = TestUserEmail3
+                }
+            };
+            var organisations = new List<McOrganisation> {
+                new McOrganisation {
+                    OrgId = "OrgId_1"
+                },
+                new McOrganisation {
+                    OrgId = "OrgId_2"
+                }
+
+            };
+
+            var institutions = new List<UcasInstitution>
+            {
+                new UcasInstitution {
+                    InstCode = "InstCode_1"
+                },
+                new UcasInstitution {
+                    InstCode = "InstCode_2"
+                }
+            };
+
+            var organisationInstitutions = new List<McOrganisationInstitution>
+            {
+                new McOrganisationInstitution {
+                    InstitutionCode = institutions[1].InstCode,
+                    OrgId = organisations[1].OrgId
+                }
+            };
+            var organisationUsers = new List<McOrganisationUser>
+            {
+                new McOrganisationUser {
+                    Email = TestUserEmail2,
+                },
+                new McOrganisationUser {
+                    Email = TestUserEmail3,
+                    OrgId = "OrgId_1"
+                }
+            };
+            var result = new ReferenceDataPayload
+            {
+                Users = users,
+                OrganisationInstitutions = organisationInstitutions,
+                OrganisationUsers = organisationUsers,
+                Organisations = organisations,
+                Institutions = institutions
+            };
+
+            return result;
+        }
+
+        private static UcasPayload GetUcasPayload()
+        {
+            return new UcasPayload
+            {
+                Courses = new List<UcasCourse>{
+                    new UcasCourse
+                    {
+                        InstCode = "InstCode_1",
+                        CrseCode = "CourseCode_1"
+                    }
+                }
+            };
+        }
 
         /// <summary>
         /// setup data so we can test

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -155,6 +155,31 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             }
         }
 
+        [Test]
+        public void ErroneousCourseLeavesOtherCoursesAlone()
+        {
+            Subject.ProcessReferencePayload(GetUserPayload());
+
+            var import = GetUcasPayload();
+
+            //make dodgy
+            import.Courses = import.Courses.Concat(new List<UcasCourse>() {new UcasCourse {InstCode = "DOESNOTEXIST", CrseCode = "Foo"}});
+            Subject.ProcessUcasPayload(import);
+
+            Assert.AreEqual(1, Context.CourseCodes.Count(), "valid courses should be imported anyway");
+            Assert.AreEqual(1, Context.UcasCourses.Count(), "valid courses should be imported anyway");
+
+            //make an update and change import order
+            import.Courses.First().CrseTitle = "The best title";
+            import.Courses = import.Courses.Reverse();
+
+            Subject.ProcessUcasPayload(import);
+
+            Assert.AreEqual(1, Context.CourseCodes.Count(), "valid courses should be re-imported anyway");
+            Assert.AreEqual(1, Context.UcasCourses.Count(), "valid courses should be re-imported anyway");
+            Assert.AreEqual("The best title", Context.UcasCourses.Single().CrseTitle);
+        }
+
 
 
         public ReferenceDataPayload GetUserPayload()

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -27,20 +27,6 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
 
         protected override void Setup()
         {
-            Context.UcasCourses.RemoveRange(Context.UcasCourses);
-            Context.CourseCodes.RemoveRange(Context.CourseCodes);
-            Context.UcasSubjects.RemoveRange(Context.UcasSubjects);
-            Context.UcasCourseSubjects.RemoveRange(Context.UcasCourseSubjects);
-            Context.UcasCampuses.RemoveRange(Context.UcasCampuses);
-            Context.UcasCourseNotes.RemoveRange(Context.UcasCourseNotes);
-            Context.UcasNoteTexts.RemoveRange(Context.UcasNoteTexts);
-            Context.McOrganisationIntitutions.RemoveRange(Context.McOrganisationIntitutions);
-            Context.UcasInstitutions.RemoveRange(Context.UcasInstitutions);
-            Context.McOrganisations.RemoveRange(Context.McOrganisations);
-            Context.McOrganisationUsers.RemoveRange(Context.McOrganisationUsers);
-            Context.McUsers.RemoveRange(Context.McUsers);
-            Context.Save();
-
             var mockLogger = new Mock<ILogger<DataService>>();
             DataService = new DataService(Context, new UserDataHelper(), mockLogger.Object);
         }

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -182,6 +182,15 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             Assert.AreEqual("The best title", Context.UcasCourses.Single().CrseTitle);
         }
 
+        [Test]
+        public void ImportDoesntLoseEnrichment()
+        {
+            // do an import, inst A,B
+            // add enrichment to A,B
+            // do another import with some modified data, inst B,C (A is gone)
+            // check the enrichment of B didn't go missing
+        }
+
         [TestCase("nothing@nowhere.com", null)]
         public void GetCoursesForUser_isNull(string email, string orgId)
         {

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -171,32 +171,6 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             Assert.AreEqual("The best title", Context.UcasCourses.Single().CrseTitle);
         }
 
-        [Test]
-        public void ImportDoesntLoseEnrichment()
-        {
-            // set up ref data in context
-            // do an import
-            DataService.ProcessReferencePayload(todo);
-            // add enrichment to A,B
-            var enrichmentService = new EnrichmentService(Context);
-            var enrichmentModel = new UcasInstitutionEnrichmentPostModel
-            {
-                EnrichmentModel = new InstitutionEnrichmentModel
-                {
-                    TrainWithUs = @"Come with us
-And leave your Earth behind
-Bright and clear
-We see the light
-All universes at your side",
-                }
-            };
-            enrichmentService.SaveInstitutionEnrichment(enrichmentModel, InstCode1, TestUserEmail1);
-            // do another import with some modified data, inst B,C (A is gone)
-            DataService.ProcessReferencePayload(todo);
-            // check the enrichment of B didn't go missing
-            Assert.Todo()
-        }
-
         [TestCase("nothing@nowhere.com", null)]
         public void GetCoursesForUser_isNull(string email, string orgId)
         {

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -19,6 +19,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
     public class DataServiceTests : DbIntegrationTestBase
     {
         public IDataService DataService;
+        private const string InstCode1 = "InstCode_1";
 
         private const string TestUserEmail1 = "email_1@test-manage-courses.gov.uk";
         private const string TestUserEmail2 = "email_2@test-manage-courses.gov.uk";
@@ -404,7 +405,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             var institutions = new List<UcasInstitution>
             {
                 new UcasInstitution {
-                    InstCode = "InstCode_1"
+                    InstCode = InstCode1
                 },
                 new UcasInstitution {
                     InstCode = "InstCode_2"
@@ -447,7 +448,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 Courses = new List<UcasCourse>{
                     new UcasCourse
                     {
-                        InstCode = "InstCode_1",
+                        InstCode = InstCode1,
                         CrseCode = "CourseCode_1"
                     }
                 }

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -47,22 +47,22 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         [Test]
         public void ProcessPayload()
         {
-            var userPayload = GetUserPayload();
-            DataService.ProcessReferencePayload(userPayload);
+            var referenceDataPayload = GetReferenceDataPayload();
+            DataService.ProcessReferencePayload(referenceDataPayload);
 
-            var payload = GetUcasPayload();
+            var payload = GetUcasCoursesPayload();
             DataService.ProcessUcasPayload(payload);
 
             foreach (var item in Context.McUsers)
             {
-                var payloadUser = userPayload.Users.FirstOrDefault(
+                var payloadUser = referenceDataPayload.Users.FirstOrDefault(
                     x => x.FirstName == item.FirstName &&
                     x.LastName == item.LastName &&
                     x.Email == item.Email);
 
                 Assert.IsNotNull(payloadUser);
 
-                var payloadOrgUser = userPayload.OrganisationUsers.FirstOrDefault(x => x.Email == payloadUser.Email);
+                var payloadOrgUser = referenceDataPayload.OrganisationUsers.FirstOrDefault(x => x.Email == payloadUser.Email);
 
                 if (payloadOrgUser != null)
                 {
@@ -90,8 +90,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         [Test]
         public void RepeatImportsArePossible()
         {
-            var payload = GetUcasPayload();
-            var userPayload = GetUserPayload();
+            var payload = GetUcasCoursesPayload();
+            var userPayload = GetReferenceDataPayload();
 
             DataService.ProcessReferencePayload(userPayload);
             DataService.ProcessUcasPayload(payload);
@@ -156,9 +156,9 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         [Test]
         public void ErroneousCourseLeavesOtherCoursesAlone()
         {
-            DataService.ProcessReferencePayload(GetUserPayload());
+            DataService.ProcessReferencePayload(GetReferenceDataPayload());
 
-            var import = GetUcasPayload();
+            var import = GetUcasCoursesPayload();
 
             //make dodgy
             import.Courses = import.Courses.Concat(new List<UcasCourse>
@@ -368,7 +368,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             }
         }
 
-        private static ReferenceDataPayload GetUserPayload()
+        private static ReferenceDataPayload GetReferenceDataPayload()
         {
             var users = new List<McUser>
             {
@@ -440,7 +440,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             return result;
         }
 
-        private static UcasPayload GetUcasPayload()
+        private static UcasPayload GetUcasCoursesPayload()
         {
             return new UcasPayload
             {

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using GovUk.Education.ManageCourses.Api.Data;
 using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.Api.Services;
 using GovUk.Education.ManageCourses.Api.Services.Data;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using GovUk.Education.ManageCourses.Domain.Models;
@@ -173,10 +174,27 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         [Test]
         public void ImportDoesntLoseEnrichment()
         {
-            // do an import, inst A,B
+            // set up ref data in context
+            // do an import
+            DataService.ProcessReferencePayload(todo);
             // add enrichment to A,B
+            var enrichmentService = new EnrichmentService(Context);
+            var enrichmentModel = new UcasInstitutionEnrichmentPostModel
+            {
+                EnrichmentModel = new InstitutionEnrichmentModel
+                {
+                    TrainWithUs = @"Come with us
+And leave your Earth behind
+Bright and clear
+We see the light
+All universes at your side",
+                }
+            };
+            enrichmentService.SaveInstitutionEnrichment(enrichmentModel, InstCode1, TestUserEmail1);
             // do another import with some modified data, inst B,C (A is gone)
+            DataService.ProcessReferencePayload(todo);
             // check the enrichment of B didn't go missing
+            Assert.Todo()
         }
 
         [TestCase("nothing@nowhere.com", null)]


### PR DESCRIPTION
### Context
The basic flow is wrapping it in a transaction for deleting and adding and also for recovery.

When a transaction completes it either commits or rollback if it fails.


It has a recovery for the purpose of deleting the item concerned and adding a new version back if it fails to add the new version it uses the deleted copy as recovery as ef do insert before deletion


### Changes proposed in this pull request
Isolate failures in UCAS importer for robustness
