### PR TITLE
Configure SeriLog to send to ApplicationInsightsEvents

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ For more information see:
 * https://github.com/serilog/serilog-settings-configuration
 * https://nblumhardt.com/2016/07/serilog-2-minimumlevel-override/
 
+Serilog has been configured to spit logs out to both the console
+(for `dotnet run` testing & development locally) and Application Insights.
+
+Set the `APPINSIGHTS_INSTRUMENTATIONKEY` environment variable to tell Serilog the application insights key.
+
 # Running tests
 
 ## Unit tests

--- a/src/ManageCourses.Api/ManageCourses.Api.csproj
+++ b/src/ManageCourses.Api/ManageCourses.Api.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.12" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="2.6.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Trace" Version="2.1.0" />
   </ItemGroup>

--- a/src/ManageCourses.Api/Program.cs
+++ b/src/ManageCourses.Api/Program.cs
@@ -11,8 +11,11 @@ namespace GovUk.Education.ManageCourses.Api
     {
         public static int Main(string[] args)
         {
+            var configuration = GetConfiguration();
             Log.Logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(LoggerConfiguration)
+                .ReadFrom.Configuration(configuration)
+                .WriteTo
+                .ApplicationInsightsTraces(configuration["APPINSIGHTS_INSTRUMENTATIONKEY"])
                 .CreateLogger();
 
             var programLogger = Log.ForContext<Program>();
@@ -36,7 +39,7 @@ namespace GovUk.Education.ManageCourses.Api
 
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
-                .UseKestrel(options => 
+                .UseKestrel(options =>
                 {
                     options.AddServerHeader = false;
                 })
@@ -44,11 +47,14 @@ namespace GovUk.Education.ManageCourses.Api
                 .UseSerilog()
                 .Build();
 
-        private static IConfiguration LoggerConfiguration { get; } = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-            .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true)
-            .AddEnvironmentVariables()
-            .Build();
+        private static IConfiguration GetConfiguration()
+        {
+            return new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", optional: true)
+                .AddEnvironmentVariables()
+                .Build();
+        }
     }
 }


### PR DESCRIPTION
### Context

Azure-friendly log setup.

Now logs to both app insights **and** the console. Hurrah.

Will need the APPINSIGHTS_INSTRUMENTATIONKEY env var in prod.