### PR TITLE
Nctl orgs

### DIFF
--- a/src/ManageCourses.Api/Model/ReferenceDataPayload.cs
+++ b/src/ManageCourses.Api/Model/ReferenceDataPayload.cs
@@ -8,12 +8,14 @@ namespace GovUk.Education.ManageCourses.Api.Model
         public ReferenceDataPayload()
         {
             this.Organisations = new List<McOrganisation>();
+            this.NctlOrganisation = new List<NctlOrganisation>();
             this.Institutions = new List<UcasInstitution>();
             this.OrganisationInstitutions = new List<McOrganisationInstitution>();
             this.OrganisationUsers = new List<McOrganisationUser>();
             this.Users = new List<McUser>();
         }
         public IEnumerable<McOrganisation> Organisations { get; set; }
+        public IEnumerable<NctlOrganisation> NctlOrganisation { get; set; }
         public IEnumerable<UcasInstitution> Institutions { get; set; }
         public IEnumerable<McOrganisationInstitution> OrganisationInstitutions { get; set; }
         public IEnumerable<McOrganisationUser> OrganisationUsers { get; set; }

--- a/src/ManageCourses.Api/Services/Data/DataService.cs
+++ b/src/ManageCourses.Api/Services/Data/DataService.cs
@@ -258,6 +258,16 @@ namespace GovUk.Education.ManageCourses.Api.Services.Data
                     }
                     );
             }
+            foreach (var nctlOrganisation in payload.NctlOrganisation)
+            {
+                _context.AddNctlOrganisation(
+                    new NctlOrganisation
+                    {
+                        NctlId = nctlOrganisation.NctlId,
+                        OrgId = nctlOrganisation.OrgId,
+                        Name = nctlOrganisation.Name
+                    });
+            }
             foreach (var institution in payload.Institutions)
             {
                 _context.AddUcasInstitution(

--- a/src/ManageCourses.Domain/DatabaseAccess/IManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/IManageCoursesDbContext.cs
@@ -41,6 +41,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
         void AddUcasCampus(UcasCampus campus);
         void AddUcasCourseNote(UcasCourseNote courseNote);
         void AddUcasNoteText(UcasNoteText noteText);
+        void AddNctlOrganisation(NctlOrganisation nctlOrganisation);
         void AddMcOrganisation(McOrganisation organisation);
         void AddMcOrganisationInstitution(McOrganisationInstitution organisationInstitution);
         void AddMcOrganisationUser(McOrganisationUser organisationUser);

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -248,6 +248,11 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
             McOrganisations.Add(organisation);
         }
 
+        public void AddNctlOrganisation(NctlOrganisation organisation)
+        {
+            NctlOrganisations.Add(organisation);
+        }
+
         public void AddMcOrganisationInstitution(McOrganisationInstitution organisationInstitution)
         {
             McOrganisationIntitutions.Add(organisationInstitution);

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -108,6 +108,13 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                 .HasForeignKey(ucs => new { ucs.InstCode, ucs.CrseCode })
                 .HasPrincipalKey(cc => new { cc.InstCode, cc.CrseCode });
 
+            modelBuilder.Entity<NctlOrganisation>()
+                .HasOne(x => x.McOrganisation)                
+                .WithMany(x => x.NctlOrganisations)
+                .HasForeignKey(x => x.OrgId)
+                .HasPrincipalKey(x => x.OrgId)
+                .OnDelete(DeleteBehavior.Cascade);
+
             modelBuilder.Entity<AccessRequest>()
                 .HasOne(ar => ar.Requester)
                 .WithMany(u => u.AccessRequests)
@@ -139,6 +146,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
         public DbSet<UcasCampus> UcasCampuses { get; set; }
         public DbSet<UcasCourseNote> UcasCourseNotes { get; set; }
         public DbSet<UcasNoteText> UcasNoteTexts { get; set; }
+        public DbSet<NctlOrganisation> NctlOrganisations { get; set; }
         public DbSet<McOrganisation> McOrganisations { get; set; }
         public DbSet<McOrganisationInstitution> McOrganisationIntitutions { get; set; }
         public DbSet<McOrganisationUser> McOrganisationUsers { get; set; }

--- a/src/ManageCourses.Domain/Migrations/20180821174525_AddNctlOrganisation.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180821174525_AddNctlOrganisation.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180821174525_AddNctlOrganisation")]
+    partial class AddNctlOrganisation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20180821174525_AddNctlOrganisation.cs
+++ b/src/ManageCourses.Domain/Migrations/20180821174525_AddNctlOrganisation.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class AddNctlOrganisation : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "nctl_organisation",
+                columns: table => new
+                {
+                    id = table.Column<int>(nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.SerialColumn),
+                    name = table.Column<string>(nullable: true),
+                    nctl_id = table.Column<string>(nullable: false),
+                    org_id = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_nctl_organisation", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_nctl_organisation_mc_organisation_org_id",
+                        column: x => x.org_id,
+                        principalTable: "mc_organisation",
+                        principalColumn: "org_id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_nctl_organisation_org_id",
+                table: "nctl_organisation",
+                column: "org_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "nctl_organisation");
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/McOrganisation.cs
+++ b/src/ManageCourses.Domain/Models/McOrganisation.cs
@@ -10,5 +10,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 
         public ICollection<McOrganisationUser> McOrganisationUsers { get; set; }
         public ICollection<McOrganisationInstitution> McOrganisationInstitutions { get; set; }
+
+        public ICollection<NctlOrganisation> NctlOrganisations { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/NctlOrganisation.cs
+++ b/src/ManageCourses.Domain/Models/NctlOrganisation.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace GovUk.Education.ManageCourses.Domain.Models
+{
+    public class NctlOrganisation
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string NctlId { get; set; }
+
+        public string OrgId { get; set; }
+
+        public string Name { get; set; }
+
+        public McOrganisation McOrganisation { get; set; }
+    }
+}


### PR DESCRIPTION
### Context

When adding users, they usually know which "NCTL Organisation" they belong to, and what "UCAS institutions" they own, but our `org_id` concept is new and unknown. To action access requests, we need to be able to inspect which NCTL Organisation belong to which `org_id`

### Changes proposed in this pull request

This introduces a new entity `NctlOrganisation`, with a many-to-one relationship to `McOrganisation`. The new entities are added to the ReferenceData Payload class and import method.

### Guidance to review

The following file imports the production reference data: [import.zip](https://github.com/DFE-Digital/manage-courses-api/files/2307527/import.zip)



