### PR TITLE
Fix enrichment where different user touched the data

### DIFF
--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -31,7 +31,11 @@ namespace GovUk.Education.ManageCourses.Api.Services
         {
             ValidateUserOrg(email, instCode);
 
-            var enrichment = _context.InstitutionEnrichments.Where(ie => instCode.ToLower() == ie.InstCode.ToLower()).OrderByDescending(x => x.Id).FirstOrDefault();
+            var enrichment = _context.InstitutionEnrichments.Where(ie => instCode.ToLower() == ie.InstCode.ToLower())
+                .OrderByDescending(x => x.Id)
+                .Include(e => e.CreatedByUser)
+                .Include(e => e.UpdatedByUser)
+                .FirstOrDefault();
             var enrichmentToReturn = Convert(enrichment);
 
             return enrichmentToReturn;


### PR DESCRIPTION
Current user was already loaded by EF, other users weren't
resulting in a null ref exception when accessing InstitutionEnrichment.CreatedByUser.Id in Convert()

Adds 2x include statements, re-wraps the line.