### PR TITLE
add a HomeController

### DIFF
--- a/src/ManageCourses.Api/Controllers/HomeController.cs
+++ b/src/ManageCourses.Api/Controllers/HomeController.cs
@@ -1,0 +1,22 @@
+
+using GovUk.Education.ManageCourses.Api.ActionFilters;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GovUk.Education.ManageCourses.Api.Controllers
+{
+    ///<summary>
+    /// Simple root endpoint.
+    ///</summary>
+    public class HomeController : Controller
+    {
+        ///<summary>
+        /// takes you to swagger.
+        ///</summary>
+        [ExemptFromAcceptTerms]
+        [Route("/")]
+        public IActionResult Index()
+        {
+            return Redirect("/swagger");
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/Controllers/HomeControllerTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/Controllers/HomeControllerTests.cs
@@ -1,0 +1,24 @@
+﻿using FluentAssertions;
+using GovUk.Education.ManageCourses.Api.Controllers;
+using GovUk.Education.ManageCourses.Api.Exceptions;
+using GovUk.Education.ManageCourses.Api.Services.Invites;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Controllers
+{
+    [TestFixture]
+    public class HomeControllerTests
+    {
+        [Test]
+        public void Index()
+        {
+            var controller = new HomeController();
+            var res = controller.Index() as RedirectResult;
+
+            Assert.NotNull(res);
+            Assert.AreEqual("/swagger", res.Url);
+        }
+    }
+}


### PR DESCRIPTION
### Context

https://trello.com/c/9QA33BK0/194-500-errors-in-publish-courses-api-without-stack-trace

### Changes proposed in this pull request

Add a home controller to serve route, "/", redirect to swagger UI

### Guidance to review

n/a

