### PR TITLE
Save multiple courses

### DIFF
--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -151,7 +151,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
         {
             var userInst = ValidateUserOrg(email, instCode);
 
-            var enrichmentDraftRecord = _context.CourseEnrichments.Where(ie => instCode.ToLower() == ie.InstCode.ToLower() && ie.Status == EnumStatus.Draft).OrderByDescending(x => x.Id).FirstOrDefault();
+            var enrichmentDraftRecord = _context.CourseEnrichments.Where(ie => instCode.ToLower() == ie.InstCode.ToLower() && ucasCourseCode.ToLower() == ie.UcasCourseCode.ToLower() && ie.Status == EnumStatus.Draft).OrderByDescending(x => x.Id).FirstOrDefault();
 
             var content = JsonConvert.SerializeObject(model, _jsonSerializerSettings);
 

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
@@ -164,7 +164,20 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             var publishedCount = Context.CourseEnrichments.Count(x => x.Status == EnumStatus.Published);
             publishedCount.Should().Be(1);
             draftCount.Should().Be(1);
+
+            // test saving & loading a different course in the same institution
+            var nextCourseModel = new CourseEnrichmentModel
+            {
+                AboutCourse = "Some other course",
+            };
+            const string otherCourseCode = "D0H";
+            enrichmentService.SaveCourseEnrichment(nextCourseModel, ProviderInstCode.ToLower(), otherCourseCode, Email);
+            var nextCourseGet = enrichmentService.GetCourseEnrichment(ProviderInstCode.ToLower(), otherCourseCode, Email);
+            nextCourseGet.Should().NotBeNull();
+            nextCourseGet.EnrichmentModel.Should().NotBeNull();
+            nextCourseGet.EnrichmentModel.AboutCourse.Should().BeEquivalentTo(nextCourseModel.AboutCourse);
         }
+
         [Test]
         [TestCase("eqweqw", "qweqweq")]
         public void Test_SaveCourseEnrichment_should_return_invalid_operation_exception(string instCode, string email)


### PR DESCRIPTION
### Context

Random failure to save course enrichment turned out to be because the get within the save that is used to merge new data in to an existing record was missing the filter to course code (following copy-paste from org enrichment)

### Changes proposed in this pull request

* Add test coverage.
* Add missing filter.

### Guidance to review

Nothing to see here. Click approve and move along. :eyeglasses: 