### PR TITLE
hotfix access request failing because First name and last name of cur…

### DIFF
--- a/src/ManageCourses.Api/Controllers/AccessRequestController.cs
+++ b/src/ManageCourses.Api/Controllers/AccessRequestController.cs
@@ -27,16 +27,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         public StatusCodeResult Index([FromBody] AccessRequest request) 
         {
             var requesterEmail = this.User.Identity.Name;
-            
-            try
-            {
-                _service.LogAccessRequest(request, requesterEmail);
-            }
-            catch (Exception)
-            {
-                return StatusCode(500);
-            }            
-        
+            _service.LogAccessRequest(request, requesterEmail);        
             return StatusCode(200);
             
         }

--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -91,7 +91,9 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
             return new JsonUserDetails
             {
                 Email = session.McUser.Email,
-                Subject = session.Subject
+                Subject = session.Subject,
+                GivenName = session.McUser.FirstName,
+                FamilyName = session.McUser.LastName
             };
         }
 


### PR DESCRIPTION
### Context

hotfix access request failing because First name and last name of current user get set to blank on sign in when access token is cached

