### PR TITLE
Cascade email updates to org-user [wip]

### DIFF
--- a/src/ManageCourses.Api/Services/Users/UserService.cs
+++ b/src/ManageCourses.Api/Services/Users/UserService.cs
@@ -74,7 +74,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
 
         private static void UpdateMcUserFromSignIn(McUser user, JsonUserDetails userDetails)
         {
-            //user.Email = userDetails.Email; // todo: update email address from sign-in. blocked by use of email as a foreign-key
+            user.Email = userDetails.Email;
             user.FirstName = userDetails.GivenName;
             user.LastName = userDetails.FamilyName;
         }

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -30,7 +30,8 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                 .HasOne(ou => ou.McUser)
                 .WithMany(u => u.McOrganisationUsers)
                 .HasForeignKey(ou => ou.Email)
-                .HasPrincipalKey(u => u.Email);
+                .HasPrincipalKey(u => u.Email)
+                .OnDelete(DeleteBehavior.Cascade);
             modelBuilder.Entity<McOrganisationUser>()
                 .HasOne(ou => ou.McOrganisation)
                 .WithMany(u => u.McOrganisationUsers)

--- a/src/ManageCourses.Domain/Migrations/20180905144836_CascadeUserOrg.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180905144836_CascadeUserOrg.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180905144836_CascadeUserOrg")]
+    partial class CascadeUserOrg
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20180905144836_CascadeUserOrg.cs
+++ b/src/ManageCourses.Domain/Migrations/20180905144836_CascadeUserOrg.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class CascadeUserOrg : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_mc_organisation_user_mc_user_email",
+                table: "mc_organisation_user");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_mc_organisation_user_mc_user_email",
+                table: "mc_organisation_user",
+                column: "email",
+                principalTable: "mc_user",
+                principalColumn: "email",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_mc_organisation_user_mc_user_email",
+                table: "mc_organisation_user");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_mc_organisation_user_mc_user_email",
+                table: "mc_organisation_user",
+                column: "email",
+                principalTable: "mc_user",
+                principalColumn: "email",
+                onDelete: ReferentialAction.Restrict);
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Migrations/20180905144836_CascadeUserOrg.cs
+++ b/src/ManageCourses.Domain/Migrations/20180905144836_CascadeUserOrg.cs
@@ -18,7 +18,8 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
                 column: "email",
                 principalTable: "mc_user",
                 principalColumn: "email",
-                onDelete: ReferentialAction.Cascade);
+                onDelete: ReferentialAction.Cascade,
+                onUpdate: ReferentialAction.Cascade);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -33,7 +34,8 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
                 column: "email",
                 principalTable: "mc_user",
                 principalColumn: "email",
-                onDelete: ReferentialAction.Restrict);
+                onDelete: ReferentialAction.Restrict,
+                onUpdate: ReferentialAction.Restrict);
         }
     }
 }


### PR DESCRIPTION
### Context

Was doing something tenuously related and accidentally created this small improvement.

Without this you can't update any email addresses because of the FK.
This is a half-way house between that and switching to Id based FKs (which is a bigger change).

With this you can now issue an `update mc_user set email =...` and it works instead of throwing a FK error.

### Changes proposed in this pull request

Switch on cascade update/delete on the orguser-user FK.
