### PR TITLE
Populate email in identity from mc_user instead of sign-in claims [wip]

### DIFF
--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using GovUk.Education.ManageCourses.Api.Services;
 using GovUk.Education.ManageCourses.Api.Services.Users;
+using GovUk.Education.ManageCourses.Domain.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace GovUk.Education.ManageCourses.Api.Middleware
@@ -47,10 +48,11 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
             try
             {
                 var userDetails = GetJsonUserDetailsFromDatabase(accessToken) ?? GetJsonUserDetailsFromOauth(accessToken);
-                
+
+                McUser mcUser;
                 try
                 {
-                    await _userService.UserSignedInAsync(accessToken, userDetails);
+                    mcUser = await _userService.UserSignedInAsync(accessToken, userDetails);
                 }
                 catch (McUserNotFoundException)
                 {
@@ -61,7 +63,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                 var identity = new ClaimsIdentity(
                     new[] {
                         new Claim (ClaimTypes.NameIdentifier, userDetails.Subject),
-                        new Claim (ClaimTypes.Email, userDetails.Email)
+                        new Claim (ClaimTypes.Email, mcUser.Email)
                     }, BearerTokenDefaults.AuthenticationScheme, ClaimTypes.Email, null);
 
                 var princical = new ClaimsPrincipal(identity);

--- a/src/ManageCourses.Api/Services/Users/IUserService.cs
+++ b/src/ManageCourses.Api/Services/Users/IUserService.cs
@@ -1,5 +1,7 @@
 using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.Api.Exceptions;
 using GovUk.Education.ManageCourses.Api.Middleware;
+using GovUk.Education.ManageCourses.Domain.Models;
 
 namespace GovUk.Education.ManageCourses.Api.Services.Users
 {
@@ -15,7 +17,8 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
         /// </summary>
         /// <param name="accessToken">The OAuth AccessToken</param>
         /// <param name="userDetails">Details from DfE Sign-in</param>
-        /// <returns></returns>
-        Task UserSignedInAsync(string accessToken, JsonUserDetails userDetails);
+        /// <returns>The McUser record for the signed in user</returns>
+        /// <exception cref="McUserNotFoundException">Thrown if couldn't find user by subjectId or email address</exception>
+        Task<McUser> UserSignedInAsync(string accessToken, JsonUserDetails userDetails);
     }
 }

--- a/src/ManageCourses.Api/Services/Users/UserService.cs
+++ b/src/ManageCourses.Api/Services/Users/UserService.cs
@@ -26,7 +26,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
         }
 
         /// <inheritdoc />
-        public async Task UserSignedInAsync(string accessToken, JsonUserDetails userDetails)
+        public async Task<McUser> UserSignedInAsync(string accessToken, JsonUserDetails userDetails)
         {
             var mcUser = await _context.McUsers.SingleOrDefaultAsync(u => u.SignInUserId == userDetails.Subject);
             if (mcUser == null)
@@ -59,6 +59,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
 
             _context.Save();
             SendWelcomeEmail(mcUser);
+            return mcUser;
         }
 
         private void SendWelcomeEmail(McUser user)


### PR DESCRIPTION
This makes our system's knowledge of the email internally consistent.

This fixes an invalid operation exception caused by the terms filter looking for a user by email address when their sign-in email address didn't match the one in mc_users. (We could still find the user because they had previously signed in with their old address and we had their subjectId logged).
