### PR TITLE
refactor McSession

### DIFF
--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -1,34 +1,27 @@
 using System;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
-using System.Threading.Tasks;
-using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
-using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
 using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Api.Exceptions;
+using GovUk.Education.ManageCourses.Api.Services.Users;
+using Microsoft.AspNetCore.Authentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using GovUk.Education.ManageCourses.Api.Services;
-using GovUk.Education.ManageCourses.Api.Services.Users;
-using Microsoft.EntityFrameworkCore;
+using Newtonsoft.Json;
 
 namespace GovUk.Education.ManageCourses.Api.Middleware
 {
     public class BearerTokenHandler : AuthenticationHandler<BearerTokenOptions>
     {
         private readonly HttpClient _backChannel;
-        private readonly IManageCoursesDbContext _manageCoursesDbContext;
 
         private readonly IUserService _userService;
-        private ILogger<BearerTokenHandler> _logger;
+        private readonly ILogger<BearerTokenHandler> _logger;
 
-        public BearerTokenHandler(IOptionsMonitor<BearerTokenOptions> options, IManageCoursesDbContext manageCoursesDbContext, IUserService userService, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
+        public BearerTokenHandler(IOptionsMonitor<BearerTokenOptions> options, IUserService userService, ILoggerFactory logger, UrlEncoder encoder, ISystemClock clock) : base(options, logger, encoder, clock)
         {
-            _manageCoursesDbContext = manageCoursesDbContext;
             _backChannel = new HttpClient();
             _userService = userService;
             _logger = logger.CreateLogger<BearerTokenHandler>();
@@ -36,69 +29,54 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            var accessToken = Request.GetAccessToken();
-
-            if (string.IsNullOrEmpty(accessToken))
-            {
-                _logger.LogDebug("Bearer token not found in request headers");
-                return AuthenticateResult.NoResult();
-            }
-
-            SubjectAndEmail subjectAndEmail = null;
             try
             {
-                subjectAndEmail = GetSubjectAndEmailFromDatabase(accessToken);
-                if (subjectAndEmail == null)
+                var accessToken = Request.GetAccessToken();
+
+                if (string.IsNullOrEmpty(accessToken))
                 {
-                    subjectAndEmail = await GetSubjectAndEmailFromOauth(accessToken);                    
+                    _logger.LogDebug("Bearer token not found in request headers");
+                    return AuthenticateResult.NoResult();
                 }
-            }               
-            catch (McUserNotFoundException)
-            {
-                _logger.LogWarning($"SignIn subject {subjectAndEmail?.Subject} not found in McUsers data");
-                return AuthenticateResult.NoResult();
-            }            
+
+                var mcUser = await _userService.GetFromCacheAsync(accessToken);
+                var cacheMiss = mcUser == null;
+                if (cacheMiss)
+                {
+                    var userDetails = await GetDetailsFromOAuthAsync(accessToken);
+                    try
+                    {
+                        mcUser = await _userService.LoginAsync(userDetails);
+                    }
+                    catch (McUserNotFoundException ex)
+                    {
+                        _logger.LogWarning($"SignIn subject {userDetails.Subject} not found in McUsers data");
+                        return AuthenticateResult.Fail(ex);
+                    }
+                    await _userService.CacheTokenAsync(accessToken, mcUser);
+                }
+                await _userService.LoggedInAsync(mcUser);
+
+                var identity = new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.NameIdentifier, mcUser.SignInUserId),
+                    new Claim(ClaimTypes.Email, mcUser.Email)
+                }, BearerTokenDefaults.AuthenticationScheme, ClaimTypes.Email, null);
+
+                var princical = new ClaimsPrincipal(identity);
+                var ticket = new AuthenticationTicket(princical, BearerTokenDefaults.AuthenticationScheme);
+                _logger.LogDebug("User successfully signed in. SignIn-Id {0}", mcUser.SignInUserId);
+                return AuthenticateResult.Success(ticket);
+            }
             catch (Exception ex)
             {
                 return AuthenticateResult.Fail(ex);
             }
-            
-            var identity = new ClaimsIdentity(
-                new[] {
-                    new Claim (ClaimTypes.NameIdentifier, subjectAndEmail.Subject),
-                    new Claim (ClaimTypes.Email, subjectAndEmail.Email)
-                }, BearerTokenDefaults.AuthenticationScheme, ClaimTypes.Email, null);
-
-            var princical = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(princical, BearerTokenDefaults.AuthenticationScheme);
-            _logger.LogDebug("User successfully signed in. SignIn-Id {0}", subjectAndEmail.Subject);
-            return AuthenticateResult.Success(ticket);            
         }
 
-        private SubjectAndEmail GetSubjectAndEmailFromDatabase(string accessToken)
+        private async Task<JsonUserDetails> GetDetailsFromOAuthAsync(string accessToken)
         {
-            var dateCutoff = DateTime.UtcNow.AddMinutes(-30);
-            var session = _manageCoursesDbContext.McSessions
-                .Include(x => x.McUser)
-                .Where(x => x.AccessToken == accessToken && x.CreatedUtc > dateCutoff)
-                .FirstOrDefault(); /*   There is an edge case where more than one record for a valid session 
-                                        could be added, e.g. when clock skew occurs between two authentications. 
-                                        Any of these overlapping records would qualify and the redundancy is quite harmless. 
-                                        So we use First, not Single, here. */
-
-            if (session == null)
-            {
-                return null;
-            }
-
-            _userService.LogLogin(session.McUser);
-            
-            return new SubjectAndEmail(session.McUser.SignInUserId, session.McUser.Email);
-        }
-
-        private async Task<SubjectAndEmail> GetSubjectAndEmailFromOauth(string accessToken)
-        {
-            var responsesString = "";
+            string responsesString;
 
             using (var request = new HttpRequestMessage())
             {
@@ -108,11 +86,11 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                 request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
-                var response = _backChannel.SendAsync(request).Result;
+                var response = await _backChannel.SendAsync(request);
 
                 response.EnsureSuccessStatusCode();
 
-                responsesString = response.Content.ReadAsStringAsync().Result;
+                responsesString = await response.Content.ReadAsStringAsync();
             }
 
             var userDetails = JsonConvert.DeserializeObject<JsonUserDetails>(responsesString, new JsonSerializerSettings
@@ -120,13 +98,13 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                 MissingMemberHandling = MissingMemberHandling.Ignore
             });
 
-            await _userService.UserSignedInAsync(accessToken, userDetails);
-
-            return new SubjectAndEmail(userDetails.Subject, userDetails.Email);
+            return userDetails;
         }
 
         protected override Task HandleChallengeAsync(AuthenticationProperties properties)
         {
+            // this method is pretend-async because it's an override!!
+
             var authResult = HandleAuthenticateOnceSafeAsync().Result;
             if (!authResult.Succeeded && authResult.Failure != null)
             {
@@ -136,18 +114,6 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
             }
 
             return base.HandleChallengeAsync(properties);
-        }
-
-        private class SubjectAndEmail
-        {
-            public string Subject {get; private set;}
-            public string Email {get; private set;}
-
-            public SubjectAndEmail(string subject, string email)
-            {
-                Subject = subject;
-                Email = email;
-            }
         }
     }
 }

--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -46,7 +46,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                     var userDetails = await GetDetailsFromOAuthAsync(accessToken);
                     try
                     {
-                        mcUser = await _userService.LoginAsync(userDetails);
+                        mcUser = await _userService.GetAndUpdateUserAsync(userDetails);
                     }
                     catch (McUserNotFoundException ex)
                     {

--- a/src/ManageCourses.Api/Middleware/SubjectAndEmail.cs
+++ b/src/ManageCourses.Api/Middleware/SubjectAndEmail.cs
@@ -1,0 +1,14 @@
+namespace GovUk.Education.ManageCourses.Api.Middleware
+{
+    public class SubjectAndEmail
+    {
+        public string Subject { get; private set; }
+        public string Email { get; private set; }
+
+        public SubjectAndEmail(string subject, string email)
+        {
+            Subject = subject;
+            Email = email;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Services/Users/IUserService.cs
+++ b/src/ManageCourses.Api/Services/Users/IUserService.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
         /// Get the user from the claims.
         /// Updates stored user details with updated details in claims.
         /// </summary>
-        Task<McUser> LoginAsync(JsonUserDetails userDetails);
+        Task<McUser> GetAndUpdateUserAsync(JsonUserDetails userDetails);
 
         /// <summary>
         /// Call this when a user signs in.

--- a/src/ManageCourses.Api/Services/Users/IUserService.cs
+++ b/src/ManageCourses.Api/Services/Users/IUserService.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.Api.Exceptions;
 using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Domain.Models;
 
@@ -13,6 +14,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
         /// Get the user from the claims.
         /// Updates stored user details with updated details in claims.
         /// </summary>
+        /// <exception cref="McUserNotFoundException"></exception>
         Task<McUser> GetAndUpdateUserAsync(JsonUserDetails userDetails);
 
         /// <summary>

--- a/src/ManageCourses.Api/Services/Users/IUserService.cs
+++ b/src/ManageCourses.Api/Services/Users/IUserService.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Api.Middleware;
+using GovUk.Education.ManageCourses.Domain.Models;
 
 namespace GovUk.Education.ManageCourses.Api.Services.Users
 {
@@ -9,7 +10,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
     public interface IUserService
     {
         /// <summary>
-        /// Call this when a user signs in.
+        /// Call this when a user signs in and their user details have been retrieved externally
         /// Implementation will handle workflow actions
         /// that need to happen off the back of this.
         /// </summary>
@@ -17,5 +18,13 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
         /// <param name="userDetails">Details from DfE Sign-in</param>
         /// <returns></returns>
         Task UserSignedInAsync(string accessToken, JsonUserDetails userDetails);
+
+        /// <summary>
+        /// Call this when a user signs in.
+        /// This updates the login timestamps in the database.
+        /// </summary>
+        /// <param name="user">The user to be updated</param>
+        /// <returns></returns>
+        void LogLogin(McUser user);
     }
 }

--- a/src/ManageCourses.Api/Services/Users/IUserService.cs
+++ b/src/ManageCourses.Api/Services/Users/IUserService.cs
@@ -10,21 +10,28 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
     public interface IUserService
     {
         /// <summary>
-        /// Call this when a user signs in and their user details have been retrieved externally
-        /// Implementation will handle workflow actions
-        /// that need to happen off the back of this.
+        /// Get the user from the claims.
+        /// Updates stored user details with updated details in claims.
         /// </summary>
-        /// <param name="accessToken">The OAuth AccessToken</param>
-        /// <param name="userDetails">Details from DfE Sign-in</param>
-        /// <returns></returns>
-        Task UserSignedInAsync(string accessToken, JsonUserDetails userDetails);
+        Task<McUser> LoginAsync(JsonUserDetails userDetails);
 
         /// <summary>
         /// Call this when a user signs in.
-        /// This updates the login timestamps in the database.
+        /// This updates the login timestamps in the database
+        /// and sends welcome email if not already sent.
         /// </summary>
         /// <param name="user">The user to be updated</param>
-        /// <returns></returns>
-        void LogLogin(McUser user);
+        Task LoggedInAsync(McUser user);
+
+        /// <summary>
+        /// Save a copy of the access token in the cache
+        /// </summary>
+        Task CacheTokenAsync(string accessToken, McUser mcUser);
+
+        /// <summary>
+        /// Figure out who this is based on the cached access token to avoid
+        /// unnecessary round-trips to DfE Sign-in claims endpoint.
+        /// </summary>
+        Task<McUser> GetFromCacheAsync(string accessToken);
     }
 }

--- a/src/ManageCourses.Api/Services/Users/UserService.cs
+++ b/src/ManageCourses.Api/Services/Users/UserService.cs
@@ -46,16 +46,12 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
             LogLogin(mcUser);
             UpdateMcUserFromSignIn(mcUser, userDetails);
 
-            if (!_context.McSessions.Any(x => x.AccessToken == accessToken && x.CreatedUtc > _clock.UtcNow.AddMinutes(-30)))
+            _context.McSessions.Add(new McSession
             {
-                _context.McSessions.Add(new McSession
-                {
-                    AccessToken = accessToken,
-                    McUser = mcUser,
-                    Subject = userDetails.Subject,
-                    CreatedUtc = _clock.UtcNow
-                });
-            }
+                AccessToken = accessToken,
+                McUser = mcUser,
+                CreatedUtc = _clock.UtcNow
+            });
 
             _context.Save();
             SendWelcomeEmail(mcUser);

--- a/src/ManageCourses.Api/Services/Users/UserService.cs
+++ b/src/ManageCourses.Api/Services/Users/UserService.cs
@@ -75,7 +75,8 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
             user.LastName = userDetails.FamilyName;
         }
 
-        private void LogLogin(McUser user)
+        /// <inheritdoc />
+        public void LogLogin(McUser user)
         {
             user.LastLoginDateUtc = _clock.UtcNow;
             if (user.FirstLoginDateUtc == null)

--- a/src/ManageCourses.Api/Services/Users/UserService.cs
+++ b/src/ManageCourses.Api/Services/Users/UserService.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Users
         }
 
         /// <inheritdoc />
-        public async Task<McUser> LoginAsync(JsonUserDetails userDetails)
+        public async Task<McUser> GetAndUpdateUserAsync(JsonUserDetails userDetails)
         {
             var mcUser = await _context.McUsers.SingleOrDefaultAsync(u => u.SignInUserId == userDetails.Subject);
             if (mcUser == null)

--- a/src/ManageCourses.Domain/Migrations/20180907115439_SimplifyMcSession.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20180907115439_SimplifyMcSession.Designer.cs
@@ -12,9 +12,10 @@ using System;
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180907115439_SimplifyMcSession")]
+    partial class SimplifyMcSession
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20180907115439_SimplifyMcSession.cs
+++ b/src/ManageCourses.Domain/Migrations/20180907115439_SimplifyMcSession.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class SimplifyMcSession : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "subject",
+                table: "mc_session");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "subject",
+                table: "mc_session",
+                nullable: true);
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/McSession.cs
+++ b/src/ManageCourses.Domain/Models/McSession.cs
@@ -15,8 +15,6 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 
         public string AccessToken { get; set; }
 
-        public string Subject { get; set; }
-
         public DateTime CreatedUtc { get; set; }
     }
 }

--- a/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
@@ -125,9 +125,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             CheckUserDataUpdated(_testUserBob, userDetails2);
             _testUserBob.LastLoginDateUtc.Should().Be(secondSignInTime);
             _testUserBob.Sessions.Count.Should().Be(2);
-            _testUserBob.Sessions.Single(x => x.AccessToken == "abc").Subject.Should().Be(bobSubject);
             _testUserBob.Sessions.Single(x => x.AccessToken == "abc").CreatedUtc.Should().Be(firstSignInTime);
-            _testUserBob.Sessions.Single(x => x.AccessToken == "def").Subject.Should().Be(bobSubject);            
             _testUserBob.Sessions.Single(x => x.AccessToken == "def").CreatedUtc.Should().Be(secondSignInTime);
             // check original timestamps have not been altered
             _testUserBob.FirstLoginDateUtc.Should().Be(firstSignInTime);

--- a/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/UserServiceTests.cs
@@ -10,6 +10,7 @@ using GovUk.Education.ManageCourses.Api.Services.Email;
 using GovUk.Education.ManageCourses.Api.Services.Email.Model;
 using GovUk.Education.ManageCourses.Api.Services.Users;
 using GovUk.Education.ManageCourses.Domain.Models;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using NUnit.Framework;
 
@@ -71,12 +72,15 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 GivenName = "The",
                 Subject = "673535D4-3CB3-4A1D-B1F0-B0FFB787CECF",
             };
-            Func<Task> signIn = async () => { await _userService.UserSignedInAsync("abc", unknownUser); };
+            Func<Task> signIn = async () => { await _userService.GetAndUpdateUserAsync(unknownUser); };
             signIn.Should().Throw<McUserNotFoundException>($"{unknownUser.Email} / {unknownUser.Subject} does not exist in McUsers");
         }
 
+        /// <summary>
+        /// Test a realistic journey, validating the state of the data at each step
+        /// </summary>
         [Test]
-        public void SignInTest()
+        public async Task SignInTest()
         {
             var firstSignInTime = new DateTime(2017, 12, 31, 23, 59, 59);
             _mockTime = firstSignInTime;
@@ -90,10 +94,9 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 Subject = bobSubject,
             };
 
-            // test a realistic journey, validating the state of the data at each step
-
             // bob signs in for the first time
-            _userService.UserSignedInAsync("abc", userDetails1);
+            var bob = await _userService.GetAndUpdateUserAsync(userDetails1);
+            await _userService.LoggedInAsync(bob);
             // check user data updated from claims and timestamps have been set
             CheckUserDataUpdated(_testUserBob, userDetails1);
             _testUserBob.FirstLoginDateUtc.Should().Be(firstSignInTime);
@@ -120,19 +123,46 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 FamilyName = "Charlton the legend",
                 Subject = bobSubject,
             };
-            _userService.UserSignedInAsync("def", userDetails2); // would throw if it couldn't find the McUser entry
+            var bob2 = await _userService.GetAndUpdateUserAsync(userDetails2); // would throw if it couldn't find the McUser entry
+            await _userService.LoggedInAsync(bob2);
             // check user data updated from claims and timestamps have been set
             CheckUserDataUpdated(_testUserBob, userDetails2);
             _testUserBob.LastLoginDateUtc.Should().Be(secondSignInTime);
-            _testUserBob.Sessions.Count.Should().Be(2);
-            _testUserBob.Sessions.Single(x => x.AccessToken == "abc").CreatedUtc.Should().Be(firstSignInTime);
-            _testUserBob.Sessions.Single(x => x.AccessToken == "def").CreatedUtc.Should().Be(secondSignInTime);
             // check original timestamps have not been altered
             _testUserBob.FirstLoginDateUtc.Should().Be(firstSignInTime);
             _testUserBob.WelcomeEmailDateUtc.Should().Be(firstSignInTime);
 
             // check only one email was sent
             _mockWelcomeEmailService.Verify(x => x.Send(It.IsAny<WelcomeEmailModel>()), Times.Once);
+        }
+
+        [Test]
+        public async Task TestAccessTokenCaching()
+        {
+            const string token1 = "abc";
+            var firstSignInTime = new DateTime(2016, 11, 30, 22, 58, 58);
+            _mockTime = firstSignInTime;
+
+            await _userService.CacheTokenAsync(token1, _testUserBob);
+
+            // test some other token still returns null now there's some cache data
+            var unknownToken = "never-seen-before";
+            var uncachedUser = await _userService.GetFromCacheAsync(unknownToken);
+            uncachedUser.Should().BeNull($"Token '{unknownToken}' hasn't been seen before");
+
+            var cachedUser = await _userService.GetFromCacheAsync(token1);
+            cachedUser.Email.Should().Be(_testUserBob.Email, "bob has had an access token cached");
+
+            const string token2 = "def";
+            var secondSignInTime = _mockTime.AddHours(8);
+            _mockTime = secondSignInTime;
+
+            await _userService.CacheTokenAsync(token2, _testUserBob);
+
+            _testUserBob.Sessions.Count.Should().Be(2);
+            _testUserBob.Sessions.Single(x => x.AccessToken == token1).CreatedUtc.Should().Be(firstSignInTime);
+            _testUserBob.Sessions.Single(x => x.AccessToken == token2).CreatedUtc.Should().Be(secondSignInTime);
+
         }
 
         private void CheckUserDataUpdated(McUser mcUser, JsonUserDetails jsonUserDetails)


### PR DESCRIPTION
### Context

https://trello.com/c/GZWlOaG8/272-refactor-getjsonuserdetailsfromdatabase-access-token-caching
and
https://trello.com/c/DpL48FW3/271-mcsession-duplicates-subjectid

### Changes proposed in this pull request

The original implementation contained a number of redundant steps because the caching was trying to replicate too much oauth behaviour. In fact, this had caused an eleventh-hour bug that broke Access Requests by overwriting the names of users when they re-authenticated!

Two changes:
- Remove the redundant subjectId 
- Remove behaviour that attempts to update user records when the cache is hit
- generally tidy up the code a bit.

### Guidance to review

No new tests as this is almost a pure refactor with no behaviour changes. Main change is that data updates now only happen if oAuth is hit, not when the cache is hit.

