### PR TITLE
Fix api status codes for unauth'd users.

### DIFF
--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -73,7 +73,9 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
             }
             catch (Exception ex)
             {
-                throw new Exception($"Unhandled exception during bearer token authentication. SubjectId: {userDetails?.Subject ?? mcUser?.SignInUserId}", ex);
+                // todo: throw when https://trello.com/c/MjNZSdMt/55-bearer-token-handler-called-for-api-key-endpoints-timebox-30-mins is fixed (breaks tests that rely on api-key calls for setup, and probably all api-key calls)
+                //throw new Exception($"Unhandled exception during bearer token authentication. SubjectId: {userDetails?.Subject ?? mcUser?.SignInUserId}", ex);
+                return AuthenticateResult.Fail(ex);
             }
         }
 

--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -54,7 +54,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                     catch (McUserNotFoundException)
                     {
                         _logger.LogWarning($"SignIn subject {userDetails.Subject} not found in McUsers data");
-                        return AuthenticateResult.NoResult();
+                        return AuthenticateResult.NoResult(); // this will 401 which is then explicitly handled by the UI
                     }
                     await _userService.CacheTokenAsync(accessToken, mcUser);
                 }

--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -51,7 +51,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
                     {
                         mcUser = await _userService.GetAndUpdateUserAsync(userDetails);
                     }
-                    catch (McUserNotFoundException ex)
+                    catch (McUserNotFoundException)
                     {
                         _logger.LogWarning($"SignIn subject {userDetails.Subject} not found in McUsers data");
                         return AuthenticateResult.NoResult();

--- a/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenHandler.cs
@@ -73,8 +73,7 @@ namespace GovUk.Education.ManageCourses.Api.Middleware
             }
             catch (Exception ex)
             {
-                _logger.LogError($"Unhandled exception during bearer token authentication. SubjectId: {userDetails?.Subject ?? mcUser?.SignInUserId}", ex);
-                return AuthenticateResult.NoResult();
+                throw new Exception($"Unhandled exception during bearer token authentication. SubjectId: {userDetails?.Subject ?? mcUser?.SignInUserId}", ex);
             }
         }
 


### PR DESCRIPTION
Fail was causing 404 (redirect to non-existent login page we think).
Use NoResult instead to give 401.

### Context
It was all broken. UI was giving 404 instead of the "we don't know who you are" page.

### Changes proposed in this pull request
Fix it. Break the tests. >_<
