### PR TITLE
Don't hit sign-in endpoints for api-key protected endpoints

### DIFF
--- a/src/ManageCourses.Api/Controllers/AcceptTermsController.cs
+++ b/src/ManageCourses.Api/Controllers/AcceptTermsController.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using GovUk.Education.ManageCourses.Api.ActionFilters;
+using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -17,7 +18,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
             this.context = context;
         }
 
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [ExemptFromAcceptTerms]
         [HttpPost]        
         [Route("accept")]

--- a/src/ManageCourses.Api/Controllers/AcceptTermsController.cs
+++ b/src/ManageCourses.Api/Controllers/AcceptTermsController.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
             this.context = context;
         }
 
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [ExemptFromAcceptTerms]
         [HttpPost]        
         [Route("accept")]

--- a/src/ManageCourses.Api/Controllers/AcceptTermsController.cs
+++ b/src/ManageCourses.Api/Controllers/AcceptTermsController.cs
@@ -3,11 +3,10 @@ using System.Linq;
 using GovUk.Education.ManageCourses.Api.ActionFilters;
 using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
-{   
+{
     [Route("api/[controller]")]
     public class AcceptTermsController : Controller
     {
@@ -20,7 +19,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
 
         [BearerTokenAuth]
         [ExemptFromAcceptTerms]
-        [HttpPost]        
+        [HttpPost]
         [Route("accept")]
         [ProducesResponseType(404)]
         [ProducesResponseType(200)]
@@ -39,10 +38,10 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
             }
 
             user.AcceptTermsDateUtc = DateTime.UtcNow;
-            
+
             context.Save();
 
             return Ok();
-        } 
+        }
     }
 }

--- a/src/ManageCourses.Api/Controllers/AccessRequestController.cs
+++ b/src/ManageCourses.Api/Controllers/AccessRequestController.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
             _service = accessRequestService;
         }
 
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpPost]
         [ProducesResponseType(200)]
         public StatusCodeResult Index([FromBody] AccessRequest request) 

--- a/src/ManageCourses.Api/Controllers/AccessRequestController.cs
+++ b/src/ManageCourses.Api/Controllers/AccessRequestController.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Api.Data;
+using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -22,7 +23,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
             _service = accessRequestService;
         }
 
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpPost]
         [ProducesResponseType(200)]
         public StatusCodeResult Index([FromBody] AccessRequest request) 

--- a/src/ManageCourses.Api/Controllers/AccessRequestController.cs
+++ b/src/ManageCourses.Api/Controllers/AccessRequestController.cs
@@ -1,18 +1,12 @@
-using System;
-using System.Linq;
-using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Api.Data;
 using GovUk.Education.ManageCourses.Api.Middleware;
-using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using GovUk.Education.ManageCourses.Api.Model;
+using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {
-    
-    
+
+
     [Route("api/[controller]")]
     public class AccessRequestController : Controller
     {
@@ -26,11 +20,11 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         [BearerTokenAuth]
         [HttpPost]
         [ProducesResponseType(200)]
-        public StatusCodeResult Index([FromBody] AccessRequest request) 
+        public StatusCodeResult Index([FromBody] AccessRequest request)
         {
             var requesterEmail = this.User.Identity.Name;
-            _service.LogAccessRequest(request, requesterEmail);        
-            return Ok();            
+            _service.LogAccessRequest(request, requesterEmail);
+            return Ok();
         }
     }
 }

--- a/src/ManageCourses.Api/Controllers/CoursesController.cs
+++ b/src/ManageCourses.Api/Controllers/CoursesController.cs
@@ -21,7 +21,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets a course by institution Ucas code
         /// </summary>
         /// <returns>a single course</returns>
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpGet]
         [Route("{instCode}/course/{ucasCode}")]
         [ProducesResponseType(typeof(Course), 200)]
@@ -44,7 +44,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets a list of course by Inst code
         /// </summary>
         /// <returns>a single course</returns>
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpGet]
         [Route("{instCode}")]
         [ProducesResponseType(typeof(InstitutionCourses), 200)]

--- a/src/ManageCourses.Api/Controllers/CoursesController.cs
+++ b/src/ManageCourses.Api/Controllers/CoursesController.cs
@@ -1,8 +1,6 @@
-﻿using System.Collections.Generic;
-using GovUk.Education.ManageCourses.Api.Data;
+﻿using GovUk.Education.ManageCourses.Api.Data;
 using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Model;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers

--- a/src/ManageCourses.Api/Controllers/CoursesController.cs
+++ b/src/ManageCourses.Api/Controllers/CoursesController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using GovUk.Education.ManageCourses.Api.Data;
+using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Model;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -20,7 +21,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets a course by institution Ucas code
         /// </summary>
         /// <returns>a single course</returns>
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpGet]
         [Route("{instCode}/course/{ucasCode}")]
         [ProducesResponseType(typeof(Course), 200)]
@@ -43,7 +44,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets a list of course by Inst code
         /// </summary>
         /// <returns>a single course</returns>
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpGet]
         [Route("{instCode}")]
         [ProducesResponseType(typeof(InstitutionCourses), 200)]

--- a/src/ManageCourses.Api/Controllers/DataController.cs
+++ b/src/ManageCourses.Api/Controllers/DataController.cs
@@ -1,10 +1,8 @@
 using GovUk.Education.ManageCourses.Api.ActionFilters;
 using GovUk.Education.ManageCourses.Api.Data;
-using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Api.Middleware;
-using Microsoft.AspNetCore.Authorization;
+using GovUk.Education.ManageCourses.Api.Model;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {

--- a/src/ManageCourses.Api/Controllers/DataController.cs
+++ b/src/ManageCourses.Api/Controllers/DataController.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Exports the data.
         /// </summary>
         /// <returns>The exported data</returns>
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpGet]
         [Route("{ucasCode}")]
         public OrganisationCourses ExportByOrganisation(string ucasCode)

--- a/src/ManageCourses.Api/Controllers/DataController.cs
+++ b/src/ManageCourses.Api/Controllers/DataController.cs
@@ -22,7 +22,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Exports the data.
         /// </summary>
         /// <returns>The exported data</returns>
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpGet]
         [Route("{ucasCode}")]
         public OrganisationCourses ExportByOrganisation(string ucasCode)
@@ -35,7 +35,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <summary>
         /// Imports the data.
         /// </summary>
-        [Authorize(AuthenticationSchemes = BearerTokenApiKeyDefaults.AuthenticationScheme)]
+        [ApiTokenAuth]
         [ExemptFromAcceptTerms]
         [HttpPost]
         [Route("ucas")]
@@ -49,7 +49,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <summary>
         /// Imports the reference data.
         /// </summary>
-        [Authorize(AuthenticationSchemes = BearerTokenApiKeyDefaults.AuthenticationScheme)]
+        [ApiTokenAuth]
         [ExemptFromAcceptTerms]
         [HttpPost]
         [Route("referencedata")]

--- a/src/ManageCourses.Api/Controllers/DevOpsController.cs
+++ b/src/ManageCourses.Api/Controllers/DevOpsController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using GovUk.Education.ManageCourses.Api.ActionFilters;
 using GovUk.Education.ManageCourses.Api.Middleware;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;

--- a/src/ManageCourses.Api/Controllers/DevOpsController.cs
+++ b/src/ManageCourses.Api/Controllers/DevOpsController.cs
@@ -13,7 +13,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
     /// Use the actions in here to verify that various error conditions are correctly logged / alerted etc.
     /// </summary>
     [Route("api/[controller]")]
-    [Authorize(AuthenticationSchemes = BearerTokenApiKeyDefaults.AuthenticationScheme)]
+    [ApiTokenAuth]
     public class DevOpsController : Controller
     {
         /// <summary>

--- a/src/ManageCourses.Api/Controllers/EnrichmentController.cs
+++ b/src/ManageCourses.Api/Controllers/EnrichmentController.cs
@@ -2,7 +2,6 @@ using System;
 using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Api.Services;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
@@ -22,7 +21,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <param name="ucasInstitutionCode">institution code that relates to the Ucas institution of the enrichment data</param>
         /// <returns>a data object. null if not found</returns>
         [HttpGet]
-        [Route("institution/{ucasInstitutionCode}")]        
+        [Route("institution/{ucasInstitutionCode}")]
         [ProducesResponseType(typeof(UcasInstitutionEnrichmentGetModel), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -37,7 +36,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <param name="ucasInstitutionCode">institution code that relates to the Ucas institution</param>
         /// <param name="model">contains the payload that represents the data to be saved</param>
         [HttpPost]
-        [Route("institution/{ucasInstitutionCode}")]        
+        [Route("institution/{ucasInstitutionCode}")]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -51,7 +50,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <param name="ucasInstitutionCode">institution code that relates to the Ucas institution</param>
         /// <returns>true if successful</returns>
         [HttpPost]
-        [Route("institution/{ucasInstitutionCode}/publish")]        
+        [Route("institution/{ucasInstitutionCode}/publish")]
         [ProducesResponseType(typeof(bool), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -68,7 +67,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <param name="ucasCourseCode">Course code that relates to the Ucas Course of the enrichment data</param>
         /// <returns>a data object. null if not found</returns>
         [HttpGet]
-        [Route("institution/{ucasInstitutionCode}/course/{ucasCourseCode}")]        
+        [Route("institution/{ucasInstitutionCode}/course/{ucasCourseCode}")]
         [ProducesResponseType(typeof(UcasCourseEnrichmentGetModel), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -83,7 +82,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <param name="ucasCourseCode">Course code that relates to the Ucas Course</param>
         /// <param name="model">contains the payload that represents the data to be saved</param>
         [HttpPost]
-        [Route("institution/{ucasInstitutionCode}/course/{ucasCourseCode}")]        
+        [Route("institution/{ucasInstitutionCode}/course/{ucasCourseCode}")]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -98,7 +97,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// <param name="ucasInstitutionCode"></param>
         /// <param name="ucasCourseCode">Course code that relates to the Ucas Course</param>
         [HttpPost]
-        [Route("institution/{ucasInstitutionCode}/course/{ucasCourseCode}/publish")]        
+        [Route("institution/{ucasInstitutionCode}/course/{ucasCourseCode}/publish")]
         [ProducesResponseType(typeof(bool), 200)]
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
@@ -109,7 +108,8 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
 
         private ActionResult HandleVoid(Action toHandle)
         {
-            return HandleImpl(() => {
+            return HandleImpl(() =>
+            {
                 toHandle();
                 return Ok();
             });
@@ -132,7 +132,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
             catch (ArgumentNullException)
             {
                 return NotFound();
-            }            
+            }
             catch (ArgumentException)
             {
                 return BadRequest();

--- a/src/ManageCourses.Api/Controllers/EnrichmentController.cs
+++ b/src/ManageCourses.Api/Controllers/EnrichmentController.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {
-    [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+    [BearerTokenAuth]
     [Route("api/enrichment")]
     public class EnrichmentController : Controller
     {

--- a/src/ManageCourses.Api/Controllers/EnrichmentController.cs
+++ b/src/ManageCourses.Api/Controllers/EnrichmentController.cs
@@ -1,4 +1,5 @@
 using System;
+using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -6,7 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {
-    [Authorize]
+    [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
     [Route("api/enrichment")]
     public class EnrichmentController : Controller
     {

--- a/src/ManageCourses.Api/Controllers/InviteController.cs
+++ b/src/ManageCourses.Api/Controllers/InviteController.cs
@@ -9,7 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {
 
-    [Authorize(AuthenticationSchemes = BearerTokenApiKeyDefaults.AuthenticationScheme)]
+    [ApiTokenAuth]
     [Route("api/[controller]")]
     public class InviteController : Controller
     {

--- a/src/ManageCourses.Api/Controllers/InviteController.cs
+++ b/src/ManageCourses.Api/Controllers/InviteController.cs
@@ -1,9 +1,7 @@
 using GovUk.Education.ManageCourses.Api.ActionFilters;
 using GovUk.Education.ManageCourses.Api.Exceptions;
 using GovUk.Education.ManageCourses.Api.Middleware;
-using GovUk.Education.ManageCourses.Api.Services;
 using GovUk.Education.ManageCourses.Api.Services.Invites;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
@@ -21,7 +19,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         }
 
         [HttpPost]
-        [ExemptFromAcceptTerms]                
+        [ExemptFromAcceptTerms]
         [ProducesResponseType(200)]
         [ProducesResponseType(400)]
         public StatusCodeResult Index(string email)

--- a/src/ManageCourses.Api/Controllers/OrganisationsController.cs
+++ b/src/ManageCourses.Api/Controllers/OrganisationsController.cs
@@ -23,7 +23,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets an organisations by Institution Code
         /// </summary>
         /// <returns>a single UserOrganisation object</returns>
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpGet]
         [Route("{instCode}")]
         [ProducesResponseType(typeof(UserOrganisation), 200)]
@@ -46,7 +46,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets UCAS Institution data by Institution Code
         /// </summary>
         /// <returns>a single UcasInstitution object</returns>
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpGet]
         [Route("{instCode}/ucas")]
         [ProducesResponseType(typeof(UcasInstitution), 200)]
@@ -69,7 +69,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets a list of organisations for the user
         /// </summary>
         /// <returns>a list of UserOrganisation objects</returns>
-        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
+        [BearerTokenAuth]
         [HttpGet]        
         [ProducesResponseType(typeof(IEnumerable<UserOrganisation>), 200)]
         [ProducesResponseType(401)]

--- a/src/ManageCourses.Api/Controllers/OrganisationsController.cs
+++ b/src/ManageCourses.Api/Controllers/OrganisationsController.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using GovUk.Education.ManageCourses.Api.Data;
+using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Domain.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -22,7 +23,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets an organisations by Institution Code
         /// </summary>
         /// <returns>a single UserOrganisation object</returns>
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpGet]
         [Route("{instCode}")]
         [ProducesResponseType(typeof(UserOrganisation), 200)]
@@ -45,7 +46,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets UCAS Institution data by Institution Code
         /// </summary>
         /// <returns>a single UcasInstitution object</returns>
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpGet]
         [Route("{instCode}/ucas")]
         [ProducesResponseType(typeof(UcasInstitution), 200)]
@@ -68,7 +69,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// Gets a list of organisations for the user
         /// </summary>
         /// <returns>a list of UserOrganisation objects</returns>
-        [Authorize]
+        [Authorize(AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme)]
         [HttpGet]        
         [ProducesResponseType(typeof(IEnumerable<UserOrganisation>), 200)]
         [ProducesResponseType(401)]

--- a/src/ManageCourses.Api/Controllers/OrganisationsController.cs
+++ b/src/ManageCourses.Api/Controllers/OrganisationsController.cs
@@ -4,7 +4,6 @@ using GovUk.Education.ManageCourses.Api.Data;
 using GovUk.Education.ManageCourses.Api.Middleware;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Domain.Models;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
@@ -70,7 +69,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         /// </summary>
         /// <returns>a list of UserOrganisation objects</returns>
         [BearerTokenAuth]
-        [HttpGet]        
+        [HttpGet]
         [ProducesResponseType(typeof(IEnumerable<UserOrganisation>), 200)]
         [ProducesResponseType(401)]
         public IActionResult GetAll()

--- a/src/ManageCourses.Api/Middleware/ApiTokenAuthAttribute.cs
+++ b/src/ManageCourses.Api/Middleware/ApiTokenAuthAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ManageCourses.Api.Middleware
+{
+    public class ApiTokenAuthAttribute : AuthorizeAttribute
+    {
+        public ApiTokenAuthAttribute()
+        {
+            AuthenticationSchemes = BearerTokenApiKeyDefaults.AuthenticationScheme;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Middleware/BearerTokenAuthAttribute.cs
+++ b/src/ManageCourses.Api/Middleware/BearerTokenAuthAttribute.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.AspNetCore.Authorization;
+
+namespace GovUk.Education.ManageCourses.Api.Middleware
+{
+    public class BearerTokenAuthAttribute : AuthorizeAttribute
+    {
+        public BearerTokenAuthAttribute()
+        {
+            AuthenticationSchemes = BearerTokenDefaults.AuthenticationScheme;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -36,7 +36,7 @@ namespace GovUk.Education.ManageCourses.Api
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddLogging(loggingBuilder =>
-      	    loggingBuilder.AddSerilog(dispose: true));
+                loggingBuilder.AddSerilog(dispose: true));
 
             var mcConfig = new McConfig(Configuration);
             var connectionString = mcConfig.BuildConnectionString();
@@ -52,17 +52,15 @@ namespace GovUk.Education.ManageCourses.Api
 
             services.AddScoped<IManageCoursesDbContext>(provider => provider.GetService<ManageCoursesDbContext>());
 
-            services.AddAuthentication(options =>
-            {
-                options.DefaultAuthenticateScheme = BearerTokenDefaults.AuthenticationScheme;
-                options.DefaultChallengeScheme = BearerTokenDefaults.AuthenticationScheme;
-            }).AddBearerToken(options =>
-            {
-                options.UserinfoEndpoint = Configuration["auth:oidc:userinfo_endpoint"];
-            }).AddBearerTokenApiKey(options =>
-            {
-                options.ApiKey = Configuration["api:key"];
-            });
+            services.AddAuthentication()
+                .AddBearerToken(options =>
+                {
+                    options.UserinfoEndpoint = Configuration["auth:oidc:userinfo_endpoint"];
+                })
+                .AddBearerTokenApiKey(options =>
+                {
+                    options.ApiKey = Configuration["api:key"];
+                });
 
             services.AddScoped<IDataService, DataService>();
             services.AddScoped<IUserService, UserService>();

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -52,6 +52,8 @@ namespace GovUk.Education.ManageCourses.Api
 
             services.AddScoped<IManageCoursesDbContext>(provider => provider.GetService<ManageCoursesDbContext>());
 
+            // No default auth method has been set here because each action must explictly be decorated with
+            // either BearerTokenAuthAttribute or ApiTokenAuthAttribute to avoid unwanted calls to the wrong one.
             services.AddAuthentication()
                 .AddBearerToken(options =>
                 {


### PR DESCRIPTION
### Context

API was hitting sign-in end point for every api-key based request causing extra load, errors and confusion.

### Changes proposed in this pull request

* Remove default schemes
* Specify scheme on every endpoint

