### PR TITLE
Config validation to pin down cause of flapping test

### DIFF
--- a/src/ManageCourses.Api/McConfig.cs
+++ b/src/ManageCourses.Api/McConfig.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 
 namespace GovUk.Education.ManageCourses.Api
 {
@@ -9,6 +10,16 @@ namespace GovUk.Education.ManageCourses.Api
         public McConfig(IConfiguration configuration)
         {
             _configuration = configuration;
+        }
+
+        public void Validate()
+        {
+            // evaluate all properties for side-effect of checking for missing values
+            string value;
+            value = PgServer;
+            value = PgDatabase;
+            value = PgUser;
+            value = PgPassword;
         }
 
         /// <summary>
@@ -30,11 +41,21 @@ namespace GovUk.Education.ManageCourses.Api
             return connectionString;
         }
 
-        private string PgServer => _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
-        private string PgPort => _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
-        private string PgDatabase => _configuration["PG_DATABASE"];
-        private string PgUser => _configuration["PG_USERNAME"];
-        private string PgPassword => _configuration["PG_PASSWORD"];
+        private string PgServer => GetRequired("MANAGE_COURSES_POSTGRESQL_SERVICE_HOST");
+        private string PgPort => _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"] ?? "5432";
+        private string PgDatabase => GetRequired("PG_DATABASE");
+        private string PgUser => GetRequired("PG_USERNAME");
+        private string PgPassword => GetRequired("PG_PASSWORD");
         private string PgSsl => _configuration["PG_SSL"];
+
+        private string GetRequired(string key)
+        {
+            var value = _configuration[key];
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new Exception($"Config value missing: '{key}'");
+            }
+            return value;
+        }
     }
 }

--- a/src/ManageCourses.Api/McConfig.cs
+++ b/src/ManageCourses.Api/McConfig.cs
@@ -45,7 +45,7 @@ namespace GovUk.Education.ManageCourses.Api
         private string PgPort => _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"] ?? "5432";
         private string PgDatabase => GetRequired("PG_DATABASE");
         private string PgUser => GetRequired("PG_USERNAME");
-        private string PgPassword => GetRequired("PG_PASSWORD");
+        private string PgPassword => _configuration["PG_PASSWORD"];
         private string PgSsl => _configuration["PG_SSL"];
 
         private string GetRequired(string key)

--- a/src/ManageCourses.Api/McConfig.cs
+++ b/src/ManageCourses.Api/McConfig.cs
@@ -16,18 +16,25 @@ namespace GovUk.Education.ManageCourses.Api
         /// </summary>
         public string BuildConnectionString()
         {
-            var server = _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
-            var port = _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
+            var server = PgServer;
+            var port = PgPort;
 
-            var user = _configuration["PG_USERNAME"];
-            var pword = _configuration["PG_PASSWORD"];
-            var dbase = _configuration["PG_DATABASE"];
+            var user = PgUser;
+            var pword = PgPassword;
+            var dbase = PgDatabase;
 
             var sslDefault = "SSL Mode=Prefer;Trust Server Certificate=true";
-            var ssl = _configuration["PG_SSL"] ?? sslDefault;
+            var ssl = PgSsl ?? sslDefault;
 
             var connectionString = $"Server={server};Port={port};Database={dbase};User Id={user};Password={pword};{ssl}";
             return connectionString;
         }
+
+        private string PgServer => _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"];
+        private string PgPort => _configuration["MANAGE_COURSES_POSTGRESQL_SERVICE_PORT"];
+        private string PgDatabase => _configuration["PG_DATABASE"];
+        private string PgUser => _configuration["PG_USERNAME"];
+        private string PgPassword => _configuration["PG_PASSWORD"];
+        private string PgSsl => _configuration["PG_SSL"];
     }
 }

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -39,6 +39,7 @@ namespace GovUk.Education.ManageCourses.Api
                 loggingBuilder.AddSerilog(dispose: true));
 
             var mcConfig = new McConfig(Configuration);
+            mcConfig.Validate();
             var connectionString = mcConfig.BuildConnectionString();
 
             services.AddEntityFrameworkNpgsql()

--- a/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
@@ -19,12 +19,14 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         protected IConfigurationRoot Config;
         protected DateTime MockTime;
         protected Mock<IClock> MockClock;
+        protected TestConfigReader TestConfig;
 
         [OneTimeSetUp]
         public virtual void BaseOneTimeSetUp()
         {
             Config = TestConfigBuilder.BuildTestConfig();
             Context = ContextLoader.GetDbContext(Config);
+            TestConfig = new TestConfigReader(Config);
             Context.Database.EnsureDeleted();
             Context.Database.Migrate();
             MockClock = new Mock<IClock>();

--- a/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
@@ -193,18 +193,15 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 
         private void SetupSmokeTestData()
         {
-            var dfeSignInConfig = GetSigninConfig(Config);
             var clientImport = BuildApiKeyClient();
-            clientImport.Data_ImportReferenceDataAsync(TestPayloadBuilder.MakeReferenceDataPayload(dfeSignInConfig["username"])).Wait();
+            clientImport.Data_ImportReferenceDataAsync(TestPayloadBuilder.MakeReferenceDataPayload(TestConfig.SignInUsername)).Wait();
             clientImport.Data_ImportAsync(TestPayloadBuilder.MakeSimpleUcasPayload()).Wait();
         }
 
         private ManageCoursesApiClient BuildSigninAwareClient()
         {
-            var dfeSignInConfig = GetSigninConfig(Config);
-            var communicator = new DfeSignInCommunicator(dfeSignInConfig["host"], dfeSignInConfig["redirect_host"],
-                dfeSignInConfig["clientid"], dfeSignInConfig["clientsecret"]);
-            var accessToken = communicator.GetAccessTokenAsync(dfeSignInConfig["username"], dfeSignInConfig["password"]).Result;
+            var communicator = new DfeSignInCommunicator(TestConfig);
+            var accessToken = communicator.GetAccessTokenAsync(TestConfig).Result;
             var clientExport = new ManageCoursesApiClient(new MockApiClientConfiguration(accessToken), new HttpClient())
             {
                 BaseUrl = LocalWebHost.Address
@@ -220,11 +217,6 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
                 BaseUrl = LocalWebHost.Address
             };
             return importClient;
-        }
-
-        private static IConfigurationSection GetSigninConfig(IConfiguration configuration)
-        {
-            return configuration.GetSection("credentials").GetSection("dfesignin");
         }
     }
 }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
@@ -141,7 +141,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [Test]
         public async Task Invite()
         {
-            var accessToken = Config["api:key"];
+            var accessToken = TestConfig.ApiKey;
 
             var httpClient = new HttpClient();
 
@@ -214,7 +214,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 
         private ManageCoursesApiClient BuildApiKeyClient(string apiKey = null)
         {
-            var apiKeyAccessToken = apiKey ?? Config["api:key"];
+            var apiKeyAccessToken = apiKey ?? TestConfig.ApiKey;
             var importClient = new ManageCoursesApiClient(new MockApiClientConfiguration(apiKeyAccessToken), new HttpClient())
             {
                 BaseUrl = LocalWebHost.Address

--- a/tests/ManageCourses.Tests/TestConfigReader.cs
+++ b/tests/ManageCourses.Tests/TestConfigReader.cs
@@ -5,6 +5,8 @@ namespace GovUk.Education.ManageCourses.Tests
 {
     public class TestConfigReader
     {
+        const string SignInPrefix = "credentials:dfesignin:";
+
         private readonly IConfiguration _configuration;
 
         public TestConfigReader(IConfiguration configuration)
@@ -13,6 +15,13 @@ namespace GovUk.Education.ManageCourses.Tests
         }
 
         public string ApiKey => GetRequired("api:key");
+
+        public string SignInHost => GetRequired(SignInPrefix + "host");
+        public string SignInRedirectHost => GetRequired(SignInPrefix + "redirect_host");
+        public string SignInUsername => GetRequired(SignInPrefix + "username");
+        public string SignInClientId => GetRequired(SignInPrefix + "clientid");
+        public string SignInClientSecret => GetRequired(SignInPrefix + "clientsecret");
+        public string SignInPassword => GetRequired(SignInPrefix + "password");
 
         private string GetRequired(string key)
         {

--- a/tests/ManageCourses.Tests/TestConfigReader.cs
+++ b/tests/ManageCourses.Tests/TestConfigReader.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+
+namespace GovUk.Education.ManageCourses.Tests
+{
+    public class TestConfigReader
+    {
+        private readonly IConfiguration _configuration;
+
+        public TestConfigReader(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public string ApiKey => GetRequired("api:key");
+
+        private string GetRequired(string key)
+        {
+            var value = _configuration[key];
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new Exception($"Config value missing: '{key}'");
+            }
+            return value;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/ContextLoader.cs
@@ -13,6 +13,7 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
         public static ManageCoursesDbContext GetDbContext(IConfiguration config)
         {
             var mcConfig = new McConfig(config);
+            mcConfig.Validate();
             var connectionString = mcConfig.BuildConnectionString();
 
             var options = new DbContextOptionsBuilder<ManageCoursesDbContext>()

--- a/tests/ManageCourses.Tests/TestUtilities/DfeSignInCommunicator.cs
+++ b/tests/ManageCourses.Tests/TestUtilities/DfeSignInCommunicator.cs
@@ -19,42 +19,22 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
 
         private readonly SimpleHttpBrowser _httpBrowser = new SimpleHttpBrowser();
 
-        public DfeSignInCommunicator(string dfeSignInDomain, string redirectUriHostAndPort, string clientId, string clientSecret)
+        public DfeSignInCommunicator(TestConfigReader config)
         {
-            if (string.IsNullOrEmpty(dfeSignInDomain))
-            {
-                throw new ArgumentException("required", nameof(dfeSignInDomain));
-            }
-
-            if (string.IsNullOrEmpty(redirectUriHostAndPort))
-            {
-                throw new ArgumentException("required", nameof(redirectUriHostAndPort));
-            }
-
-            if (string.IsNullOrEmpty(clientId))
-            {
-                throw new ArgumentException("required", nameof(clientId));
-            }
-
-            if (string.IsNullOrEmpty(clientSecret))
-            {
-                throw new ArgumentException("required", nameof(clientSecret));
-            }
-
-            _dfeSignInDomain = dfeSignInDomain;
-            _redirectUriHostAndPort = redirectUriHostAndPort;
-            _clientId = clientId;
-            _clientSecret = clientSecret;
+            _dfeSignInDomain = config.SignInHost;
+            _redirectUriHostAndPort = config.SignInRedirectHost;
+            _clientId = config.SignInClientId;
+            _clientSecret = config.SignInClientSecret;
         }
 
-        public async Task<string> GetAccessTokenAsync(string username, string password)
+        public async Task<string> GetAccessTokenAsync(TestConfigReader config)
         {
             var startUrl = $"https://{_dfeSignInDomain}/auth?redirect_uri=https://{_redirectUriHostAndPort}/auth/cb&scope=openid profile email&response_type=code&state=1238&client_id={_clientId}";
             var loginPage = await GetUrl(startUrl, true);
 
             var form1 = await PostForm(loginPage, new Dictionary<string, string>{
-                    {"username", username},
-                    {"password", password},
+                    {"username", config.SignInUsername},
+                    {"password", config.SignInPassword},
                 }, true);
 
             var form2 = await PostForm(form1, new Dictionary<string, string>(), false);
@@ -78,13 +58,13 @@ namespace GovUk.Education.ManageCourses.Tests.TestUtilities
                 string accessToken = JObject.Parse(json)["access_token"].Value<string>();
                 if (string.IsNullOrEmpty(accessToken))
                 {
-                    throw new Exception($"could not get access_token with settings: {_clientId}, {username}, {_clientSecret.Substring(0, 3)}, {password.Substring(0, 3)}");
+                    throw new Exception($"could not get access_token with settings: {_clientId}, {config.SignInUsername}, {_clientSecret.Substring(0, 3)}, {config.SignInPassword.Substring(0, 3)}");
                 }
                 return accessToken;
             }
             catch (JsonReaderException)
             {
-                throw new Exception($"could not get access_token with settings: {_clientId}, {username}, {_clientSecret.Substring(0, 3)}, {password.Substring(0, 3)}");
+                throw new Exception($"could not get access_token with settings: {_clientId}, {config.SignInUsername}, {_clientSecret.Substring(0, 3)}, {config.SignInPassword.Substring(0, 3)}");
             }
         }
 

--- a/tests/ManageCourses.Tests/UnitTesting/Controllers/AcceptTermsControllerTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/Controllers/AcceptTermsControllerTests.cs
@@ -67,7 +67,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Controllers
             (res as StatusCodeResult).StatusCode.Should().Be(200);
             context.VerifyAll();
             list[0].AcceptTermsDateUtc.Should().NotBeNull();
-            list[0].AcceptTermsDateUtc.Should().BeCloseTo(DateTime.UtcNow);
+            list[0].AcceptTermsDateUtc.Should().BeCloseTo(DateTime.UtcNow, precision: 100); // widened precision from 20 to 100 as was flapping locally
 
         }
         

--- a/tests/ManageCourses.Tests/UnitTesting/McConfigTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/McConfigTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using GovUk.Education.ManageCourses.Api;
+using Microsoft.Extensions.Configuration;
+using Moq;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting
+{
+    [TestFixture]
+    public class McConfigTests
+    {
+        [Test]
+        public void MissingThrows()
+        {
+            var config = new Mock<IConfiguration>(); // none of the config mocked
+            var mcConfig = new McConfig(config.Object);
+            Assert.Throws<Exception>(mcConfig.Validate);
+        }
+
+        [Test]
+        public void WhitespaceThrows()
+        {
+            var config = new Mock<IConfiguration>(); // none of the config mocked
+            config.SetupGet(c => c[It.IsAny<string>()]).Returns("   ");
+            var mcConfig = new McConfig(config.Object);
+            Assert.Throws<Exception>(mcConfig.Validate);
+        }
+
+        [Test]
+        public void AllAvailableDoesntThrow()
+        {
+            var config = new Mock<IConfiguration>();
+            //config.SetupGet(c => c["MANAGE_COURSES_POSTGRESQL_SERVICE_HOST"]).Returns("hello");
+            config.SetupGet(c => c[It.IsAny<string>()]).Returns("hello");
+            var mcConfig = new McConfig(config.Object);
+            mcConfig.Validate();
+        }
+    }
+}


### PR DESCRIPTION
### Context

One of our tests has been intermittently failing with a null ref.
I have a hunch it's something config related so this PR tightens up the config handling.

### Changes proposed in this pull request

* Strongly typed config
* Validate config earlier
