### PR TITLE
set security headers in production

### DIFF
--- a/src/ManageCourses.Api/ApplicationBuilderSecurityExtensions.cs
+++ b/src/ManageCourses.Api/ApplicationBuilderSecurityExtensions.cs
@@ -1,0 +1,20 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Primitives;
+
+namespace GovUk.Education.ManageCourses.Api
+{
+    public static class ApplicationBuilderSecurityExtensions
+    {
+        public static IApplicationBuilder SetSecurityHeaders(this IApplicationBuilder app)
+        {        
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers["X-Frame-Options"] = new StringValues("SAMEORIGIN");
+                context.Response.Headers["Strict-Transport-Security"] = new StringValues("31536000; preload");
+                await next();
+            });
+
+            return app;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -103,6 +103,10 @@ namespace GovUk.Education.ManageCourses.Api
             {
                 app.UseDeveloperExceptionPage();
             }
+            else
+            {
+                app.SetSecurityHeaders();
+            }
 
             // Enable the Swagger UI middleware and the Swagger generator
             app.UseSwaggerUi3(typeof(Startup).GetTypeInfo().Assembly, settings =>


### PR DESCRIPTION
### Context

Quick fixes from the pen test

### Changes proposed in this pull request

Add two headers (`X-Frame-Options` and `Strict-Transport-Security`) that prevent clickjacking and man-in-the-middle attacks during the initial HTTP-->HTTPS redirect, respectively.