### PR TITLE
Map UCAS subjects to our vision of subjects

### DIFF
--- a/src/ManageCourses.ApiClient/CourseMapper.cs
+++ b/src/ManageCourses.ApiClient/CourseMapper.cs
@@ -13,6 +13,8 @@ namespace GovUk.Education.ManageCourses.ApiClient
 {
     public class CourseMapper : ICourseMapper
     {
+        private SubjectMapper subjectMapper = new SubjectMapper();
+
         public SearchAndCompare.Domain.Models.Course MapToSearchAndCompareCourse(ApiClient.UcasInstitution ucasInstData, ApiClient.Course ucasCourseData, InstitutionEnrichmentModel orgEnrichmentModel, CourseEnrichmentModel courseEnrichmentModel)
         {
             ucasInstData = ucasInstData ?? new ApiClient.UcasInstitution();
@@ -20,6 +22,19 @@ namespace GovUk.Education.ManageCourses.ApiClient
             ucasCourseData.Schools = ucasCourseData.Schools ?? new ObservableCollection<School>();
             orgEnrichmentModel = orgEnrichmentModel ?? new InstitutionEnrichmentModel();
             courseEnrichmentModel = courseEnrichmentModel ?? new CourseEnrichmentModel();
+
+            var subjectStrings = string.IsNullOrWhiteSpace(ucasCourseData.Subjects)
+                ? new string[]{}
+                : subjectMapper.GetSubjectList(ucasCourseData.Name, ucasCourseData.Subjects.Split(", "));
+
+            var subjects = new Collection<CourseSubject>(subjectStrings.Select(subject =>
+                new CourseSubject
+                {
+                    Subject = new Subject
+                    {
+                        Name = subject
+                    }
+                }).ToList());
 
             var provider = new SearchAndCompare.Domain.Models.Provider
             {
@@ -74,17 +89,7 @@ namespace GovUk.Education.ManageCourses.ApiClient
                             }
                         }
                     ).ToList()),
-                CourseSubjects = string.IsNullOrWhiteSpace(ucasCourseData.Subjects)
-                    ? new Collection<CourseSubject>()
-                    : new Collection<CourseSubject>(ucasCourseData.Subjects.Split(", ").Select(subject =>
-                        new CourseSubject
-                        {
-                            Subject = new Subject
-                            {
-                                Name = subject
-                            }
-
-                        }).ToList()),
+                CourseSubjects = subjects,
                 Fees = fees,
 
                 IsSalaried = isSalaried,

--- a/src/ManageCourses.ApiClient/SubjectMapper.cs
+++ b/src/ManageCourses.ApiClient/SubjectMapper.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+
+namespace GovUk.Education.ManageCourses.ApiClient
+{
+    public class SubjectMapper
+    {
+        private static string[] ucasEnglish;
+        private static string[] ucasMflMandarin;
+        private static string[] ucasFurtherEducation;
+        private static string[] ucasPrimary;
+        private static string[] ucasIct;
+        private static string[] ucasLanguageCat;
+        private static string[] ucasOther;
+        private static string[] ucasMathemtics;
+        private static string[] ucasPhysics;
+        private static string[] ucasScienceFields;
+        private static string[] ucasMflMain;
+        private static string[] ucasMflOther;
+        private static string[] ucasMflWelsh;
+        private static string[] ucasDesignAndTech;
+        private static string[] ucasDirectTranslationSecondary;
+        private static string[] ucasNeedsMentionInTitle;
+        private static string[] ucasUnexpected;
+
+        private static IDictionary<string,string> ucasRename;
+
+        static SubjectMapper()
+        {
+            ucasEnglish = new string[] 
+            {                
+                "english",
+                "english language",
+                "english literature"
+            };
+
+            ucasMflMandarin = new string[]
+            {                
+                "chinese",
+                "mandarin"  
+            };
+
+            ucasMflMain = new string[] 
+            {              
+                "french",
+                "german",
+                "italian",
+                "japanese",
+                "latin",              
+                "russian",
+                "spanish"
+            };
+
+            ucasMflOther = new string[] 
+            {            
+                "arabic",
+                "bengali",
+                "gaelic",
+                "greek",
+                "hebrew",
+                "urdu",
+                "mandarin",
+                "punjabi"
+            };
+
+            ucasMflWelsh = new string[] {
+                "welsh"
+            };
+
+            ucasDesignAndTech = new string[]
+            {
+                "design and technology",
+                "design and technology (food)",
+                "design and technology (product design)",
+                "design and technology (systems and control)",
+                "design and technology (textiles)",
+                "engineering"
+            };
+
+            ucasDirectTranslationSecondary = new string[]
+            {
+                "art / art & design",
+                "business education",
+                "citizenship",
+                "classics",
+                "communication and media studies",
+                "computer studies",                
+                "dance and performance",
+                "drama and theatre studies",                
+                "economics",
+                "geography",
+                "health and social care",                
+                "history",
+                "music",
+                "outdoor activities",
+                "physical education",
+                "psychology",
+                "religious education",
+                "social science"
+            };
+
+            ucasNeedsMentionInTitle = new string[] 
+            {
+                "humanities",
+                "science",
+                "modern studies"            
+            };
+
+            ucasFurtherEducation = new string[] 
+            {
+                "english as a second or other language",
+                "further education",
+                "higher education",
+                "literacy",
+                "numeracy",
+                "post-compulsory"
+            };
+
+            ucasPrimary = new string[] 
+            { 
+                "early years",
+                "upper primary",
+                "primary",
+                "lower primary"
+            };
+
+            ucasIct = new string[] {
+                "information communication technology",
+                "information technology"
+            };
+
+            ucasLanguageCat = new string[] 
+            {
+                "languages",
+                "languages (african)",
+                "languages (asian)",
+                "languages (european)"
+            };
+
+            ucasOther = new string [] 
+            {
+                "leisure and tourism",
+                "special educational needs"
+            };
+
+            ucasMathemtics = new string[] 
+            {            
+                "mathematics",
+                "mathematics (abridged)"
+            };
+
+            ucasPhysics = new string[] 
+            {
+                "physics",
+                "physics (abridged)"
+            };            
+
+            ucasScienceFields = new string[] 
+            {
+                "biology",
+                "chemistry"
+            };
+                
+            ucasUnexpected = new string[]
+            {
+                "construction and the built environment",
+                "history of art",
+                "home economics",
+                "hospitality and catering",
+                "personal and social education",
+                "philosophy",
+                "sport and leisure",
+                "environmental science",
+                "law"
+            };
+
+            ucasRename = new Dictionary<string,string>()
+            {
+                {"chinese", "mandarin"},
+                {"art / art & design", "art and design"},
+                {"business education", "business studies"},
+                {"computer studies", "computing"},
+                {"dance and performance", "dance"},
+                {"drama and theatre studies", "drama"},
+                {"social science", "social sciences"}
+            };
+        }
+        public IEnumerable<string> GetSubjectList(string courseTitle, IEnumerable<string> ucasSubjects)
+        {            
+            ucasSubjects = ucasSubjects.Select(x => x.ToLowerInvariant().Trim());
+            courseTitle = courseTitle.ToLowerInvariant().Trim();
+
+            // if unexpected throw.
+            if (ucasSubjects.Intersect(ucasUnexpected).Any())
+            {
+                throw new ArgumentException("found unsupported subject name");
+            }            
+            
+            // Primary?
+            else if (ucasSubjects.Intersect(ucasPrimary).Any())
+            {
+                return MapToPrimarySubjects(ucasSubjects);
+            }
+            
+            // further education?
+            else if (ucasSubjects.Intersect(ucasFurtherEducation).Any())
+            {
+                return new List<string>() { "Further education" };                
+            }
+
+            // now we're in secondary world
+            else
+            {
+                return MapToSecondarySubjects(courseTitle, ucasSubjects);
+            }
+        }
+
+        private IEnumerable<string> MapToPrimarySubjects(IEnumerable<string> ucasSubjects)
+        {
+            var primarySubjects = new List<string>() { "Primary" };
+
+            var ucasPrimaryLanguageSpecialisation = new string[] {}            
+                .Concat(ucasLanguageCat)
+                .Concat(ucasMflMain)
+                .Concat(ucasMflOther);
+
+            var ucasPrimaryScienceSpecialisation = new string[] {"science"}            
+                .Concat(ucasMathemtics)
+                .Concat(ucasPhysics)
+                .Concat(ucasScienceFields);
+
+            if(ucasSubjects.Intersect(ucasEnglish).Any())
+            {
+                primarySubjects.Add("Primary with English");
+            }
+
+            if(ucasSubjects.Contains("geography"))
+            {
+                primarySubjects.Add("Primary with geography");
+            }
+
+            if(ucasSubjects.Contains("history"))
+            {
+                primarySubjects.Add("Primary with history");
+            }
+
+            if(ucasSubjects.Intersect(ucasMathemtics).Any())
+            {
+                primarySubjects.Add("Primary with mathematics");
+            }
+
+            if(ucasSubjects.Intersect(ucasPrimaryLanguageSpecialisation).Any())
+            {
+                primarySubjects.Add("Primary with modern languages");
+            }            
+
+            if(ucasSubjects.Contains("physical education"))
+            {
+                primarySubjects.Add("Primary with physical education");
+            }
+
+            if(ucasSubjects.Intersect(ucasPrimaryScienceSpecialisation).Any())
+            {
+                primarySubjects.Add("Primary with science");
+            }
+
+            return primarySubjects;
+        }
+
+        public IEnumerable<string> MapToSecondarySubjects(string courseTitle, IEnumerable<string> ucasSubjects)
+        {
+            var secondarySubjects = new List<string>();
+
+            //  maths
+            if (ucasSubjects.Intersect(ucasMathemtics).Any())
+            {
+                secondarySubjects.Add("Mathematics");
+            }
+
+            //  physics
+            if (ucasSubjects.Intersect(ucasPhysics).Any())
+            {
+                secondarySubjects.Add("Physics");
+            }
+
+            //  ict
+            if (ucasSubjects.Intersect(ucasIct).Any())
+            {
+                secondarySubjects.Add("Information and communication technology (ICT)");
+            }
+
+            //  dt
+            if (ucasSubjects.Intersect(ucasDesignAndTech).Any())
+            {
+                secondarySubjects.Add("Design and technology");
+            }
+
+            //  mfl other
+            if (ucasSubjects.Intersect(ucasLanguageCat).Any() && !ucasSubjects.Intersect(ucasMflMandarin).Any() && !ucasSubjects.Intersect(ucasMflMain).Any())
+            {
+                secondarySubjects.Add("Modern language (other)");
+            }
+
+            // mfl - mandarin chinese
+            if (ucasSubjects.Intersect(ucasMflMandarin).Any())
+            {
+                secondarySubjects.Add("Mandarin");
+            }
+
+            //  mfl
+            foreach(var ucasSubject in ucasSubjects.Intersect(ucasMflMain))
+            {
+                secondarySubjects.Add(MapToSubjectName(ucasSubject));
+            }
+
+            //  sciences
+            foreach(var ucasSubject in ucasSubjects.Intersect(ucasScienceFields))
+            {
+                secondarySubjects.Add(MapToSubjectName(ucasSubject));
+            }
+
+            //  direct translation
+            foreach(var ucasSubject in ucasSubjects.Intersect(ucasDirectTranslationSecondary))
+            {
+                secondarySubjects.Add(MapToSubjectName(ucasSubject));
+            }
+
+            //  needs mention
+            foreach(var ucasSubject in ucasSubjects.Intersect(ucasNeedsMentionInTitle))
+            {
+                if (courseTitle.IndexOf(ucasSubject) > -1)
+                {
+                    secondarySubjects.Add(MapToSubjectName(ucasSubject));
+                }
+            }
+
+            //  english (check title if not only one ambiguous)
+            if (ucasSubjects.Intersect(ucasEnglish).Any())
+            {
+                if (!secondarySubjects.Any() || courseTitle.IndexOf("english") > -1)
+                {
+                    secondarySubjects.Add("English");
+                }
+            }
+
+            // if nothing else yet, try welsh
+            if (!secondarySubjects.Any() && ucasSubjects.Intersect(ucasMflWelsh).Any())
+            {
+                secondarySubjects.Add("Welsh");
+            }
+
+            return secondarySubjects;
+        }
+
+        private string MapToSubjectName(string ucasSubject)
+        {
+            // rename if desired
+            var res = ucasRename.TryGetValue(ucasSubject, out string mappedSubject) ? mappedSubject : ucasSubject;
+            
+            // capitalise
+            res = res.Substring(0,1).ToUpper() + res.Substring(1).ToLower();
+            
+            // ensure English is always correctly cased
+            return res.Replace("english", "English");           
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
                     ProgramType = "SS", // school direct salaried
                     Name = "Course.Name",
                     ProfpostFlag = "T", // QTS+PGCE
-                    Subjects = "Maths, Physics",
+                    Subjects = "Mathematics, Physics",
                     StudyMode = "B",
                     Schools = new ObservableCollection<School>
                     {
@@ -130,7 +130,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
 
 
             res.CourseSubjects.Count.Should().Be(2);
-            res.CourseSubjects.Any(x => x.Subject.Name == "Maths").Should().BeTrue();
+            res.CourseSubjects.Any(x => x.Subject.Name == "Mathematics").Should().BeTrue();
             res.CourseSubjects.Any(x => x.Subject.Name == "Physics").Should().BeTrue();
 
             res.Fees.Uk.Should().Be(123);

--- a/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.ApiClient;
+using GovUk.Education.SearchAndCompare.Domain.Models.Enums;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting
+{
+    [TestFixture]
+    public class SubjectMapperTests
+    {
+        [TestCase("",                       "primary, english", "Primary, Primary with English")] // an example of a primary specialisation
+        [TestCase("",                       "primary, physics", "Primary, Primary with science")] // another example of a primary specialisation
+        [TestCase("Early Years",            "primary, early years", "Primary")] // an example of early years (which is absorbed into primary)
+        [TestCase("Physics (Welsh medium)", "physics (abridged), welsh, secondary, science", "Physics")] // an example where science should be excluded because it's used as a category
+        
+        // examples of how the title is considered when adding additional subjects
+        [TestCase("Physics",   "physics, secondary, science, english", "Physics")]  
+        [TestCase("Physics with English",   "physics, secondary, science, english", "Physics, English")] 
+        [TestCase("Physics with Science",   "physics, secondary, science, english", "Physics, Science")]
+        [TestCase("Physics with Science and English",   "physics, secondary, science, english", "Physics, Science, English")]
+
+        [TestCase("Further ed",             "further education, numeracy", "Further education")] // further education examplpe
+        [TestCase("MFL (Chinese)",          "secondary, languages, languages (asian), chinese", "Mandarin")] // a rename
+        [TestCase("",                       "secondary, welsh", "Welsh")] // an example of welsh, which only triggers if nothing else goes
+        public void MapToSearchAndCompareCourse(string courseTitle, string commaSeparatedUcasSubjects, string commaSeparatedExpectedSubjects)
+        {
+            var expected = commaSeparatedExpectedSubjects.Split(", ");
+            var result = new SubjectMapper().GetSubjectList(courseTitle, commaSeparatedUcasSubjects.Split(", "));      
+
+            result.Should().BeEquivalentTo(expected);      
+        }
+
+    }
+}


### PR DESCRIPTION
### Context

We want to improve on UCAS's subject taxonomy, reducing ambiguity and raising relevance of search results.

### Changes proposed in this pull request

Introduces a mapper that evaluates the collection of UCAS subjects and the course title of a UCAS course, and turns it into a subject list matching our content design.

### Guidance to review

Due to the large number of subjects, this is a verbose pull request, please find me (@the-daniel-rothig) to walk you though.
