### PR TITLE
Fix null reference exception in AdminController

### DIFF
--- a/src/ManageCourses.Api/Controllers/AdminController.cs
+++ b/src/ManageCourses.Api/Controllers/AdminController.cs
@@ -64,7 +64,10 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         public IActionResult ActionManualActionRequest(string requesterEmail, string targetEmail, string firstName, string lastName)
         {
             requesterEmail = requesterEmail.ToLower();
-            var requesterUser = _context.McUsers.SingleOrDefault(x => x.Email == requesterEmail);
+            var requesterUser = _context.McUsers
+                .Include(x=>x.McOrganisationUsers)
+                .SingleOrDefault(x => x.Email == requesterEmail);
+                
             if (requesterUser == null)
             {
                 return NotFound();


### PR DESCRIPTION
During a manual access request, the retireval of the reference user was
incomplete. We didn't include their associated organisation so,
when it came to adding the new user to these organsiations, the org
collection could not be accessed.
