### PR TITLE
Refactor: Extract mapping logic from DataService and Enrichment service

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.Api/Mapping/CourseLoader.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using GovUk.Education.ManageCourses.Api.Data;
+using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
+using GovUk.Education.ManageCourses.Domain.EqualityComparers;
+using GovUk.Education.ManageCourses.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace GovUk.Education.ManageCourses.Api.Mapping
+{
+    public class CourseLoader
+    {
+        public InstitutionCourses LoadCourses(IEnumerable<UcasCourse> courseRecords, IEnumerable<UcasCourseEnrichmentGetModel> enrichmentMetadata)
+        {
+            var returnCourses = new InstitutionCourses();
+            if (courseRecords.Count() > 0)
+            {
+                var organisationCourseRecord = courseRecords.First();//all the records in the list hold identical institution info so just get the first one
+                returnCourses.InstitutionName = organisationCourseRecord.UcasInstitution.InstFull;
+                returnCourses.InstitutionCode = organisationCourseRecord.InstCode;
+                returnCourses.Courses = new List<Course>();
+                foreach (var courseCode in courseRecords.Select(c => c.CrseCode).Distinct())
+                {
+                    returnCourses.Courses.Add(LoadCourse(courseRecords.Where(c => c.CrseCode == courseCode).ToList(), enrichmentMetadata));
+                }
+            }
+
+            return returnCourses;
+
+        }
+        
+        public Course LoadCourse(IEnumerable<UcasCourse> courseRecords, IEnumerable<UcasCourseEnrichmentGetModel> enrichmentMetadata)
+        {
+            var returnCourse = new Course();
+            if (courseRecords.Count() > 0)
+            {
+                var organisationCourseRecord = courseRecords.First();//all the records in the list hold identical institution info so just get the first one
+
+                var bestEnrichment = enrichmentMetadata.SingleOrDefault(x => x.InstCode == organisationCourseRecord.InstCode && x.CourseCode == organisationCourseRecord.CrseCode);
+
+                returnCourse.InstCode = organisationCourseRecord.InstCode;
+                returnCourse.CourseCode = organisationCourseRecord.CrseCode;
+                returnCourse.AccreditingProviderId = organisationCourseRecord.AccreditingProvider;
+                if (organisationCourseRecord.AccreditingProviderInstitution != null)
+                {
+                    returnCourse.AccreditingProviderName = organisationCourseRecord.AccreditingProviderInstitution.InstFull;
+                }
+                returnCourse.AgeRange = organisationCourseRecord.Age;
+                returnCourse.Name = organisationCourseRecord.CrseTitle;
+                returnCourse.ProgramType = organisationCourseRecord.ProgramType;
+                returnCourse.ProfpostFlag = organisationCourseRecord.ProfpostFlag;
+                returnCourse.StudyMode = organisationCourseRecord.Studymode;
+                var subjects = organisationCourseRecord.UcasInstitution.UcasCourseSubjects
+                    .Select(x => x.UcasSubject.SubjectDescription).ToList();
+
+                returnCourse.Subjects = string.Join(", ", subjects);
+                returnCourse.Schools = GetSchoolsData(courseRecords);
+                returnCourse.EnrichmentWorkflowStatus = bestEnrichment?.Status;
+            }
+
+            return returnCourse;
+        }
+        private IEnumerable<School> GetSchoolsData(IEnumerable<UcasCourse> courseRecords)
+        {
+            var schools = courseRecords.Select(courseRecord => new School
+            {
+                LocationName = courseRecord.UcasCampus.CampusName,
+                Address1 = courseRecord.UcasCampus.Addr1,
+                Address2 = courseRecord.UcasCampus.Addr2,
+                Address3 = courseRecord.UcasCampus.Addr3,
+                Address4 = courseRecord.UcasCampus.Addr4,
+                PostCode = courseRecord.UcasCampus.Postcode,
+                ApplicationsAcceptedFrom = courseRecord.CrseOpenDate,
+                Code = courseRecord.UcasCampus.CampusCode,
+                Status = courseRecord.Status,
+            }).ToList();
+            //look for the main site and move it to the top of the list
+            var main = schools.FirstOrDefault(s => s.Code == "-");
+            if (main != null)
+            {
+                schools.Remove(main);
+                schools.Insert(0, main);
+            }
+
+            return schools;
+        }
+    }
+}

--- a/src/ManageCourses.Api/Mapping/EnrichmentConverter.cs
+++ b/src/ManageCourses.Api/Mapping/EnrichmentConverter.cs
@@ -1,0 +1,76 @@
+using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.Domain.Models;
+using Newtonsoft.Json;
+
+namespace GovUk.Education.ManageCourses.Api.Mapping
+{
+    public class EnrichmentConverter
+    {
+        private JsonSerializerSettings _jsonSerializerSettings;
+
+        public EnrichmentConverter()
+        {
+            _jsonSerializerSettings = new JsonSerializerSettings
+            {
+                MissingMemberHandling = MissingMemberHandling.Ignore,
+                NullValueHandling = NullValueHandling.Ignore
+            };
+        }        
+
+        public string ConvertToJson(UcasInstitutionEnrichmentPostModel model)
+        {
+            return JsonConvert.SerializeObject(model.EnrichmentModel, _jsonSerializerSettings);
+        }
+        
+        public string ConvertToJson(CourseEnrichmentModel model)
+        {
+            return JsonConvert.SerializeObject(model, _jsonSerializerSettings);
+        }
+        
+        /// <summary>
+        /// maps enrichment data from the data object to the returned enrichment model
+        /// </summary>
+        /// <param name="source">enrichment data object</param>
+        /// <returns>enrichment model with enrichment data (if found). Null if there is no source record</returns>
+        public UcasCourseEnrichmentGetModel Convert(CourseEnrichment source)
+        {
+            if (source == null) return null;
+
+            var enrichmentToReturn = new UcasCourseEnrichmentGetModel();
+            var enrichmentModel = source.JsonData != null ? JsonConvert.DeserializeObject<CourseEnrichmentModel>(source.JsonData, _jsonSerializerSettings) : null;
+
+            enrichmentToReturn.EnrichmentModel = enrichmentModel;
+            enrichmentToReturn.CreatedTimestampUtc = source.CreatedTimestampUtc;
+            enrichmentToReturn.UpdatedTimestampUtc = source.UpdatedTimestampUtc;
+            enrichmentToReturn.CreatedByUserId = source.CreatedByUser?.Id ?? 0;
+            enrichmentToReturn.UpdatedByUserId = source.UpdatedByUser?.Id ?? 0;
+            enrichmentToReturn.LastPublishedTimestampUtc = source.LastPublishedTimestampUtc;
+            enrichmentToReturn.Status = source.Status;
+            enrichmentToReturn.InstCode = source.InstCode;
+            enrichmentToReturn.CourseCode = source.UcasCourseCode;
+            return enrichmentToReturn;
+        }
+
+        /// <summary>
+        /// maps enrichment data from the data object to the returned enrichment model
+        /// </summary>
+        /// <param name="source">enrichment data object</param>
+        /// <returns>enrichment model with enrichment data (if found). Null if there is no source record</returns>
+        public UcasInstitutionEnrichmentGetModel Convert(InstitutionEnrichment source)
+        {
+            if (source == null) return null;
+
+            var enrichmentToReturn = new UcasInstitutionEnrichmentGetModel();
+            var enrichmentModel = source.JsonData != null ? JsonConvert.DeserializeObject<InstitutionEnrichmentModel>(source.JsonData, _jsonSerializerSettings) : null;
+
+            enrichmentToReturn.EnrichmentModel = enrichmentModel;
+            enrichmentToReturn.CreatedTimestampUtc = source.CreatedTimestampUtc;
+            enrichmentToReturn.UpdatedTimestampUtc = source.UpdatedTimestampUtc;
+            enrichmentToReturn.CreatedByUserId = source.CreatedByUser.Id;
+            enrichmentToReturn.UpdatedByUserId = source.UpdatedByUser.Id;
+            enrichmentToReturn.LastPublishedTimestampUtc = source.LastPublishedTimestampUtc;
+            enrichmentToReturn.Status = source.Status;
+            return enrichmentToReturn;
+        }
+    }
+}

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -294,6 +294,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                     and lower(ou.email)=lower(@email)", new NpgsqlParameter("instCode", instCode), new NpgsqlParameter("ucasCode", ucasCode), new NpgsqlParameter("email", email))
                 .Include(x => x.UcasInstitution)
                 .Include(x => x.UcasInstitution.UcasCourseSubjects).ThenInclude(x => x.UcasSubject)
+                .Include(x => x.CourseCode).ThenInclude(x => x.UcasCourseSubjects)
                 .Include(x => x.AccreditingProviderInstitution)
                 .Include(x => x.UcasCampus)
                 .ToList();
@@ -310,6 +311,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                     $"and lower(ou.email)=lower(@email) order by c.crse_title", new NpgsqlParameter("instCode", instCode), new NpgsqlParameter("email", email))
                 .Include(x => x.UcasInstitution)
                 .Include(x => x.UcasInstitution.UcasCourseSubjects).ThenInclude(x => x.UcasSubject)
+                .Include(x => x.CourseCode).ThenInclude(x => x.UcasCourseSubjects)
                 .Include(x => x.AccreditingProviderInstitution)
                 .Include(x => x.UcasCampus)
                 .ToList();


### PR DESCRIPTION
This splits out the methods LoadCourse and LoadCourses (and dependency methods) into a new CourseLoader class which is used by DataService.

Similarly, translating Enrichment objects to and from JSON is extracted from EnrichmentService and encapsulated in a new EnrichmentConverter class.

To keep the refactor simple the new classes are instantiated in situ.

