### PR TITLE
Move null check earlier in manual access request

### DIFF
--- a/src/ManageCourses.Api/Controllers/AdminController.cs
+++ b/src/ManageCourses.Api/Controllers/AdminController.cs
@@ -63,16 +63,16 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         [ExemptFromAcceptTerms]
         public IActionResult ActionManualActionRequest(string requesterEmail, string targetEmail, string firstName, string lastName)
         {
+            if (string.IsNullOrWhiteSpace(requesterEmail) || string.IsNullOrWhiteSpace(targetEmail))
+            {
+                return BadRequest();
+            }
+
             requesterEmail = requesterEmail.ToLower();
             var requesterUser = _context.McUsers
                 .Include(x=>x.McOrganisationUsers)
                 .SingleOrDefault(x => x.Email == requesterEmail);
 
-            if (string.IsNullOrWhiteSpace(requesterEmail) || string.IsNullOrWhiteSpace(targetEmail))
-            {
-                return BadRequest();
-            }
-                
             if (requesterUser == null)
             {
                 return NotFound();

--- a/tests/ManageCourses.Tests/DbIntegration/AdminControllerTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/AdminControllerTests.cs
@@ -89,10 +89,20 @@ namespace GovUk.Education.ManageCourses.Tests.Controllers
         }
 
         [Test]
-        public void ActionManualAccessRequest_BadRequest()
+        public void ActionManualAccessRequest_EmptyEmailBadRequest()
         {
             SaveExampleDataToContext();
             var res = new AdminController(Context).ActionManualActionRequest("", "", "Joe", "Bloggs");
+
+            (res as StatusCodeResult).StatusCode.Should().Be(400);
+            Context.AccessRequests.Count().Should().Be(1);
+        }
+
+        [Test]
+        public void ActionManualAccessRequest_NullEmailBadRequest()
+        {
+            SaveExampleDataToContext();
+            var res = new AdminController(Context).ActionManualActionRequest(null, null, "Joe", "Bloggs");
 
             (res as StatusCodeResult).StatusCode.Should().Be(400);
             Context.AccessRequests.Count().Should().Be(1);


### PR DESCRIPTION
We should check for null before we attempt to lowercase the requesterEmail.