### PR TITLE
Smarter subject mapping

### DIFF
--- a/src/ManageCourses.ApiClient/SubjectMapper.cs
+++ b/src/ManageCourses.ApiClient/SubjectMapper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Text.RegularExpressions;
 
 namespace GovUk.Education.ManageCourses.ApiClient
 {
@@ -22,7 +22,7 @@ namespace GovUk.Education.ManageCourses.ApiClient
         private static string[] ucasMflWelsh;
         private static string[] ucasDesignAndTech;
         private static string[] ucasDirectTranslationSecondary;
-        private static string[] ucasNeedsMentionInTitle;
+        private static Dictionary<string,Regex> ucasNeedsMentionInTitle;
         private static string[] ucasUnexpected;
 
         private static IDictionary<string,string> ucasRename;
@@ -101,11 +101,11 @@ namespace GovUk.Education.ManageCourses.ApiClient
                 "social science"
             };
 
-            ucasNeedsMentionInTitle = new string[] 
+            ucasNeedsMentionInTitle = new Dictionary<string, Regex>
             {
-                "humanities",
-                "science",
-                "modern studies"            
+                {"humanities", new Regex("humanities")},
+                {"science", new Regex("(?<!social |computer )science")},
+                {"modern studies", new Regex("modern studies")}            
             };
 
             ucasFurtherEducation = new string[] 
@@ -182,6 +182,7 @@ namespace GovUk.Education.ManageCourses.ApiClient
                 {"art / art & design", "art and design"},
                 {"business education", "business studies"},
                 {"computer studies", "computing"},
+                {"science", "balanced science"},
                 {"dance and performance", "dance"},
                 {"drama and theatre studies", "drama"},
                 {"social science", "social sciences"}
@@ -328,9 +329,9 @@ namespace GovUk.Education.ManageCourses.ApiClient
             }
 
             //  needs mention
-            foreach(var ucasSubject in ucasSubjects.Intersect(ucasNeedsMentionInTitle))
+            foreach(var ucasSubject in ucasSubjects.Intersect(ucasNeedsMentionInTitle.Keys))
             {
-                if (courseTitle.IndexOf(ucasSubject) > -1)
+                if (ucasNeedsMentionInTitle[ucasSubject].IsMatch(courseTitle))
                 {
                     secondarySubjects.Add(MapToSubjectName(ucasSubject));
                 }

--- a/src/ManageCourses.ApiClient/SubjectMapper.cs
+++ b/src/ManageCourses.ApiClient/SubjectMapper.cs
@@ -228,7 +228,6 @@ namespace GovUk.Education.ManageCourses.ApiClient
                 .Concat(ucasMflOther);
 
             var ucasPrimaryScienceSpecialisation = new string[] {"science"}            
-                .Concat(ucasMathemtics)
                 .Concat(ucasPhysics)
                 .Concat(ucasScienceFields);
 

--- a/src/ManageCourses.ApiClient/SubjectMapper.cs
+++ b/src/ManageCourses.ApiClient/SubjectMapper.cs
@@ -103,9 +103,9 @@ namespace GovUk.Education.ManageCourses.ApiClient
 
             ucasNeedsMentionInTitle = new Dictionary<string, Regex>
             {
-                {"humanities", new Regex("humanities")},
-                {"science", new Regex("(?<!social |computer )science")},
-                {"modern studies", new Regex("modern studies")}            
+                {"humanities", new Regex("humanities", RegexOptions.Compiled)},
+                {"science", new Regex("(?<!social |computer )science", RegexOptions.Compiled)},
+                {"modern studies", new Regex("modern studies", RegexOptions.Compiled)}            
             };
 
             ucasFurtherEducation = new string[] 

--- a/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
@@ -21,12 +21,16 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         // examples of how the title is considered when adding additional subjects
         [TestCase("Physics",   "physics, secondary, science, english", "Physics")]  
         [TestCase("Physics with English",   "physics, secondary, science, english", "Physics, English")] 
-        [TestCase("Physics with Science",   "physics, secondary, science, english", "Physics, Science")]
-        [TestCase("Physics with Science and English",   "physics, secondary, science, english", "Physics, Science, English")]
+        [TestCase("Physics with Science",   "physics, secondary, science, english", "Physics, Balanced science")]
+        [TestCase("Physics with Science and English",   "physics, secondary, science, english", "Physics, Balanced science, English")]
 
         [TestCase("Further ed",             "further education, numeracy", "Further education")] // further education examplpe
         [TestCase("MFL (Chinese)",          "secondary, languages, languages (asian), chinese", "Mandarin")] // a rename
         [TestCase("",                       "secondary, welsh", "Welsh")] // an example of welsh, which only triggers if nothing else goes
+
+        [TestCase("Computer science", "computer studies, science", "Computing")] // here science is used as a category
+        [TestCase("Computer science with Science", "computer studies, science", "Computing, Balanced science")] // here, it is explicit
+
         public void MapToSearchAndCompareCourse(string courseTitle, string commaSeparatedUcasSubjects, string commaSeparatedExpectedSubjects)
         {
             var expected = commaSeparatedExpectedSubjects.Split(", ");

--- a/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
@@ -31,6 +31,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         [TestCase("Computer science", "computer studies, science", "Computing")] // here science is used as a category
         [TestCase("Computer science with Science", "computer studies, science", "Computing, Balanced science")] // here, it is explicit
 
+        [TestCase("Primary with Mathematics", "primary, mathematics", "Primary, Primary with mathematics")] // bug fix test: accidentally included maths in the list of sciences
         public void MapToSearchAndCompareCourse(string courseTitle, string commaSeparatedUcasSubjects, string commaSeparatedExpectedSubjects)
         {
             var expected = commaSeparatedExpectedSubjects.Split(", ");


### PR DESCRIPTION
### Changes proposed in this pull request

Makes course title lookup a regex rather than a simple string search,
allowing "Balanaced science" to look for "science" but not be tricked
into accepting "computer science" or "social sciences".