### PR TITLE
Merge in ucas org contact details even if there's no enrichment

### DIFF
--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
@@ -118,7 +118,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             };
 
             var emptyEnrichment = enrichmentService.GetInstitutionEnrichment(ProviderInstCode, Email);
-            emptyEnrichment.Should().BeNull("we haven't enriched the institution data yet");
+            emptyEnrichment.Status.Should().Be(EnumStatus.Draft, "no enrichments saved yet");
 
             //test save
             enrichmentService.SaveInstitutionEnrichment(model, ProviderInstCode.ToLower(), Email);


### PR DESCRIPTION
### Context

Loading an un-enriched org showed no contact details at all, not even the ones available from the ucas data. They would then magically appear when you saved the other org enrichment fields.

### Changes proposed in this pull request

* Return merged enrichment even if there was no existing enrichment record

### Guidance to review

Note that this means that the ucas contact details will be copied into the enrichment data the first time the user hits save on any of the org enrichment data. Jake said this is fine.

