### PR TITLE
Apprenticeships are salaried

### DIFF
--- a/src/ManageCourses.ApiClient/CourseMapper.cs
+++ b/src/ManageCourses.ApiClient/CourseMapper.cs
@@ -59,7 +59,8 @@ namespace GovUk.Education.ManageCourses.ApiClient
                 };
 
             var routeName = ucasCourseData.GetRoute();
-            var isSalaried = string.Equals(ucasCourseData?.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase);
+            var isSalaried = string.Equals(ucasCourseData?.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase)
+                          || string.Equals(ucasCourseData?.ProgramType, "ta", StringComparison.InvariantCultureIgnoreCase);
             var fees = courseEnrichmentModel.FeeUkEu.HasValue ? new Fees
             {
                 Uk = (int)(courseEnrichmentModel.FeeUkEu ?? 0),


### PR DESCRIPTION
### Context

https://trello.com/c/vmeOSUpF/339-incorrectly-showing-apprenticeship-as-fee-paying

### Changes proposed in this pull request

We currently only consider `school direct (salaried)` courses as having
a salary, but this applies to Apprenticeships too: They draw a salary
and don't take fees ([source](https://www.ucas.com/teaching-option/postgraduate-teaching-apprenticeship))

this corrects course mapping to reflect that
