### PR TITLE
Remove ICT as a subject

### DIFF
--- a/src/ManageCourses.ApiClient/SubjectMapper.cs
+++ b/src/ManageCourses.ApiClient/SubjectMapper.cs
@@ -21,7 +21,6 @@ namespace GovUk.Education.ManageCourses.ApiClient
         private static string[] ucasMflMandarin;
         private static string[] ucasFurtherEducation;
         private static string[] ucasPrimary;
-        private static string[] ucasIct;
         private static string[] ucasLanguageCat;
         private static string[] ucasOther;
         private static string[] ucasMathemtics;
@@ -139,11 +138,6 @@ namespace GovUk.Education.ManageCourses.ApiClient
                 "upper primary",
                 "primary",
                 "lower primary"
-            };
-
-            ucasIct = new string[] {
-                "information communication technology",
-                "information technology"
             };
 
             ucasLanguageCat = new string[] 
@@ -320,12 +314,6 @@ namespace GovUk.Education.ManageCourses.ApiClient
             if (ucasSubjects.Intersect(ucasPhysics).Any())
             {
                 secondarySubjects.Add("Physics");
-            }
-
-            // Does the subject list mention ICT?
-            if (ucasSubjects.Intersect(ucasIct).Any())
-            {
-                secondarySubjects.Add("Information and communication technology (ICT)");
             }
 
             // Does the subject list mention D&T?

--- a/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
@@ -38,6 +38,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         [TestCase("Primary (geo)", "primary, geography", "Primary, Primary with history and geography")] // Primary with hist/geo have beeen merged
         [TestCase("Primary (history)", "primary, history", "Primary, Primary with history and geography")] // Primary with hist/geo have beeen merged
 
+        [TestCase("Computing", "secondary, computer studies, information communication technology", "Computing")] // no ICT
         public void MapToSearchAndCompareCourse(string courseTitle, string commaSeparatedUcasSubjects, string commaSeparatedExpectedSubjects)
         {
             var expected = commaSeparatedExpectedSubjects.Split(", ");


### PR DESCRIPTION
### Context

A leftover of the subject mapping exercise.

### Changes proposed in this pull request

ICT is being replaced with Computing and there are no publishable courses
that aren't also Computing. ICT is redundant.
