### PR TITLE
Fix ESOL subject mapping

### DIFF
--- a/src/ManageCourses.Api/Mapping/SubjectMapper.cs
+++ b/src/ManageCourses.Api/Mapping/SubjectMapper.cs
@@ -52,7 +52,8 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
             };
 
             ucasMflMain = new string[] 
-            {              
+            {                            
+                "english as a second or other language",  
                 "french",
                 "german",
                 "italian",
@@ -123,11 +124,8 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
 
             ucasFurtherEducation = new string[] 
             {
-                "english as a second or other language",
                 "further education",
                 "higher education",
-                "literacy",
-                "numeracy",
                 "post-compulsory"
             };
 

--- a/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SubjectMapperTests.cs
@@ -41,6 +41,10 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         [TestCase("Primary (history)", "primary, history", "Primary, Primary with history and geography")] // Primary with hist/geo have beeen merged
 
         [TestCase("Computing", "secondary, computer studies, information communication technology", "Computing")] // no ICT
+
+        [TestCase("Mandarin and ESOL", "mandarin, english as a second or other language", "Mandarin, English as a second or other language")] // secondary ESOL
+        [TestCase("PCET ESOL", "further education, english as a second or other language", "Further education")] // secondary ESOL
+
         public void MapToSearchAndCompareCourse(string courseTitle, string commaSeparatedUcasSubjects, string commaSeparatedExpectedSubjects)
         {
             var expected = commaSeparatedExpectedSubjects.Split(", ");


### PR DESCRIPTION
### Context

Zendesk ticket

### Changes proposed in this pull request

A Mandarin + English as a second or other language course was showing
as further education. This corrects this.

### Guidance to review

See test

