### PR TITLE
CourseLoader to prefer running locations

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.Api/Mapping/CourseLoader.cs
@@ -50,7 +50,12 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
             var returnCourse = new Course();
             if (courseRecords.Count() > 0)
             {
-                var organisationCourseRecord = courseRecords.First();//all the records in the list hold identical institution info so just get the first one
+                // pick a reference course record for shared data such as the accrediting provider
+                // users can edit only running locations in UCAS so give preference to using running locations
+                // if there are any.
+                var organisationCourseRecord = 
+                    courseRecords.FirstOrDefault(x => x.Status != null && x.Status.ToLowerInvariant() == "r") 
+                    ?? courseRecords.First();
 
                 var bestEnrichment = enrichmentMetadata.SingleOrDefault(x => x.InstCode == organisationCourseRecord.InstCode && x.CourseCode == organisationCourseRecord.CrseCode);
 

--- a/tests/ManageCourses.Tests/UnitTesting/Mapping/CourseLoaderTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/Mapping/CourseLoaderTests.cs
@@ -39,6 +39,41 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Mapping
             res.StartDate.Should().BeNull();
         }
 
+        [Test]
+        public void RunningLocationsArePreferred()
+        {
+            var sut = new CourseLoader();
+            var loc1 = GetBlankUcasCourse();
+            loc1.Status = "S";
+            loc1.AccreditingProvider = "WRONG_ACC";
+            loc1.InstCode = "WRONG_INST";
+
+            var loc2 = GetBlankUcasCourse();
+            loc2.Status = "R";
+            loc2.AccreditingProvider = "RIGHT_ACC";
+            loc2.InstCode = "RIGHT_INST";
+
+            var res = sut.LoadCourse(new List<UcasCourse> {loc1, loc2}, new List<UcasCourseEnrichmentGetModel>(), false);
+
+            res.AccreditingProviderId.Should().Be("RIGHT_ACC");
+            res.InstCode.Should().Be("RIGHT_INST");
+        }
+
+        [Test]
+        public void FullySuspendedCoursesWorkStill()
+        {            
+            var sut = new CourseLoader();
+            var loc1 = GetBlankUcasCourse();
+            loc1.Status = "S";
+            loc1.AccreditingProvider = "RIGHT_ACC";
+            loc1.InstCode = "RIGHT_INST";
+
+            var res = LoadCourse(sut, loc1);
+
+            res.AccreditingProviderId.Should().Be("RIGHT_ACC");
+            res.InstCode.Should().Be("RIGHT_INST");
+        }
+
         private static Course LoadCourse(CourseLoader sut, UcasCourse course)
         {
             return sut.LoadCourse(new List<UcasCourse> { course }, new List<UcasCourseEnrichmentGetModel>(), false);


### PR DESCRIPTION
### Context

Source: Zendesk

Users of UCAS weblink can only edit the data of running locations. For
this reason, when e.g. the Accrediting Training Provider changes,
there will be an inconsistency between previously discontinued locations
and current locations.

### Changes proposed in this pull request

So take data from running courses if possible.

### Guidance to review

See tests

