### PR TITLE
Added code to publish vac_status

### DIFF
--- a/src/ManageCourses.Api/ManageCourses.Api.csproj
+++ b/src/ManageCourses.Api/ManageCourses.Api.csproj
@@ -9,7 +9,7 @@
     <DocumentationFile>bin\Debug\$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.2-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.3-beta" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.8" />
     <PackageReference Include="Notify" Version="2.0.1" />

--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -90,6 +90,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                     IsSalaried = isSalaried
                 },
                 IncludesPgce = MapQualification(ucasCourseData.Qualification),
+                HasVacancies = ucasCourseData.HasVacancies,
                 Campuses = new Collection<SearchAndCompare.Domain.Models.Campus>(ucasCourseData.Schools
                     .Where(school => String.Equals(school.Status, "r", StringComparison.InvariantCultureIgnoreCase) && String.Equals(school.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
                     .Select(school =>
@@ -100,7 +101,8 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                             Location = new Location
                             {
                                 Address = MapAddress(school)
-                            }
+                            },
+                            VacStatus = school.VacStatus
                         }
                     ).ToList()),
                 CourseSubjects = subjects,

--- a/src/ManageCourses.ApiClient/ManageCourses.ApiClient.csproj
+++ b/src/ManageCourses.ApiClient/ManageCourses.ApiClient.csproj
@@ -25,7 +25,7 @@
     <Compile Remove="$(OutputSwaggerGeneration)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.2-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.3-beta" />
     <PackageReference Include="GitInfo" Version="2.0.11">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/ManageCourses.CourseExporterUtil/ManageCourses.CourseExporterUtil.csproj
+++ b/src/ManageCourses.CourseExporterUtil/ManageCourses.CourseExporterUtil.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -10,7 +10,7 @@
   <ItemGroup>
     <DotNetCliToolReference Include="Microsoft.Extensions.SecretManager.Tools" Version="2.0.2" />
     <DotNetCliToolReference Include="Microsoft.EntityFrameworkCore.Tools.DotNet" Version="2.0.3" />
-    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.2-beta" />
+    <PackageReference Include="DFE.SearchAndCompare.Domain" Version="0.10.3-beta" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />


### PR DESCRIPTION
### Context
This is part of the story to publish vac_status into search and compare.
Here is the cards: https://trello.com/c/uRcCqSlF/485-publish-per-course-vacancy-info-to-search
### Changes proposed in this pull request
Added code to the CourseMapper to pick up the new fields for course and campus/s
### Guidance to review

