### PR TITLE
Reintroduce SubjectMapper into CourseMapper

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -12,6 +12,8 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
 {
     public class CourseMapper : ICourseMapper
     {
+        private readonly SubjectMapper subjectMapper = new SubjectMapper();
+        
         public SearchAndCompare.Domain.Models.Course MapToSearchAndCompareCourse(Institution ucasInstData, Domain.Models.Course ucasCourseData, InstitutionEnrichmentModel orgEnrichmentModel, CourseEnrichmentModel courseEnrichmentModel)
         {
             ucasInstData = ucasInstData ?? new Institution();
@@ -29,12 +31,10 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                 string.IsNullOrWhiteSpace(orgEnrichmentModel.Address4) &&
                 string.IsNullOrWhiteSpace(orgEnrichmentModel.Postcode);
 
-            var subjectStrings = new List<string>();
-            if (ucasCourseData?.CourseSubjects != null) 
-            {
-                subjectStrings = ucasCourseData.CourseSubjects.Select(x => x.Subject.SubjectName).ToList();
-            }
-
+            var subjectStrings = ucasCourseData?.CourseSubjects != null
+                ? subjectMapper.GetSubjectList(ucasCourseData.Name, ucasCourseData.CourseSubjects.Select(x => x.Subject.SubjectName))
+                : new List<string>();
+            
             var subjects = new Collection<SearchAndCompare.Domain.Models.Joins.CourseSubject>(subjectStrings.Select(subject =>
                 new SearchAndCompare.Domain.Models.Joins.CourseSubject
                 {

--- a/src/ManageCourses.Api/Mapping/SubjectMapper.cs
+++ b/src/ManageCourses.Api/Mapping/SubjectMapper.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 
-namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
+namespace GovUk.Education.ManageCourses.Api.Mapping
 {
     /// <summary>
     /// This maps a list of of UCAS subjects to our interpretation of subjects.
@@ -309,7 +309,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
             return primarySubjects;
         }
 
-        public IEnumerable<string> MapToSecondarySubjects(string courseTitle, IEnumerable<string> ucasSubjects)
+        private IEnumerable<string> MapToSecondarySubjects(string courseTitle, IEnumerable<string> ucasSubjects)
         {
             var secondarySubjects = new List<string>();
 

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using GovUk.Education.ManageCourses.Api.Data;
+using GovUk.Education.ManageCourses.Api.Mapping;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using GovUk.Education.ManageCourses.Domain.Models;


### PR DESCRIPTION
### Context

Leftover from the big ol' database refactor

### Changes proposed in this pull request

We store ucas subjects in the database which need to be converted to
DfE subjects on export. This behaviour was removed temprarily when
we changed what we stored in the DB to DfE subjects.

This undoes that.


### Guidance to review

