### PR TITLE
Retry migrations for all other failure modes

### DIFF
--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -177,7 +177,12 @@ namespace GovUk.Education.ManageCourses.Api
                 }
                 catch (Exception ex)
                 {
+                    const int maxDelayMs = 60 * 1000;
                     int delayMs = 1000 * migrationAttempt;
+                    if (delayMs > maxDelayMs)
+                    {
+                        delayMs = maxDelayMs;
+                    }
                     _logger.LogError($"Failed to apply EF migrations. Attempt {migrationAttempt} of ∞. Waiting for {delayMs}ms before trying again.", ex);
                     Thread.Sleep(delayMs);
                     migrationAttempt++;

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -27,13 +27,17 @@ using NSwag.AspNetCore;
 using NSwag.SwaggerGeneration.Processors.Security;
 using Serilog;
 using System.Threading;
+using Microsoft.Extensions.Logging;
 
 namespace GovUk.Education.ManageCourses.Api
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
+        private readonly Microsoft.Extensions.Logging.ILogger _logger;
+
+        public Startup(IConfiguration configuration, ILoggerFactory logFactory)
         {
+            _logger = logFactory.CreateLogger<Startup>();
             Configuration = configuration;
         }
 
@@ -157,24 +161,25 @@ namespace GovUk.Education.ManageCourses.Api
         /// Migrate with inifinte retry.
         /// </summary>
         /// <param name="dbContext"></param>
-        private static void Migrate(ManageCoursesDbContext dbContext)
+        private void Migrate(ManageCoursesDbContext dbContext)
         {
             // If the migration fails and throws then the app ends up in a broken state so don't let that happen.
             // If the migrations failed and the exception was swallowed then the code could make assumptions that result in corrupt data so don't let execution continue till this has worked.
             int migrationAttempt = 1;
             while (true)
             {
-
                 try
                 {
+                    _logger.LogInformation($"Applying EF migrations. Attempt {migrationAttempt} of ∞");
                     dbContext.Database.Migrate();
+                    _logger.LogInformation($"Applying EF migrations succeeded. Attempt {migrationAttempt} of ∞");
                     break; // success!
                 }
                 catch (Exception ex)
                 {
-                    // todo: log, don't let this pass PR mkay?
-                    // failed. log & loop
-                    Thread.Sleep(1000 * migrationAttempt);
+                    int delayMs = 1000 * migrationAttempt;
+                    _logger.LogError($"Failed to apply EF migrations. Attempt {migrationAttempt} of ∞. Waiting for {delayMs}ms before trying again.", ex);
+                    Thread.Sleep(delayMs);
                     migrationAttempt++;
                 }
             }


### PR DESCRIPTION
### Context
The built-in retry in https://github.com/DFE-Digital/manage-courses-api/pull/227 doesn't retry for all failure modes. We don't want the app to end up in a broken state due to exceptions in startup.

### Changes proposed in this pull request

Try to migrate forever with linear back-off.

### Example output

```
Exception thrown: 'System.Net.Sockets.SocketException' in System.Private.CoreLib.dll
fail: GovUk.Education.ManageCourses.Api.Startup[0]
      Failed to apply EF migrations. Attempt 1 of ∞. Waiting for 1000ms before trying again.
GovUk.Education.ManageCourses.Api.Startup:Error: Failed to apply EF migrations. Attempt 1 of ∞. Waiting for 1000ms before trying again.
info: GovUk.Education.ManageCourses.Api.Startup[0]
      Applying EF migrations. Attempt 2 of ∞
GovUk.Education.ManageCourses.Api.Startup:Information: Applying EF migrations. Attempt 2 of ∞
Exception thrown: 'System.Net.Sockets.SocketException' in System.Private.CoreLib.dll
fail: GovUk.Education.ManageCourses.Api.Startup[0]
      Failed to apply EF migrations. Attempt 2 of ∞. Waiting for 2000ms before trying again.
GovUk.Education.ManageCourses.Api.Startup:Error: Failed to apply EF migrations. Attempt 2 of ∞. Waiting for 2000ms before trying again.
Loaded '/usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.5/System.Threading.ThreadPool.dll'. Module was built without symbols.
info: GovUk.Education.ManageCourses.Api.Startup[0]
      Applying EF migrations. Attempt 3 of ∞
GovUk.Education.ManageCourses.Api.Startup:Information: Applying EF migrations. Attempt 3 of ∞
Exception thrown: 'System.Net.Sockets.SocketException' in System.Private.CoreLib.dll
fail: GovUk.Education.ManageCourses.Api.Startup[0]
      Failed to apply EF migrations. Attempt 3 of ∞. Waiting for 3000ms before trying again.
GovUk.Education.ManageCourses.Api.Startup:Error: Failed to apply EF migrations. Attempt 3 of ∞. Waiting for 3000ms before trying again.
info: GovUk.Education.ManageCourses.Api.Startup[0]
      Applying EF migrations. Attempt 4 of ∞
GovUk.Education.ManageCourses.Api.Startup:Information: Applying EF migrations. Attempt 4 of ∞
Exception thrown: 'System.Net.Sockets.SocketException' in System.Private.CoreLib.dll
fail: GovUk.Education.ManageCourses.Api.Startup[0]
GovUk.Education.ManageCourses.Api.Startup:Error: Failed to apply EF migrations. Attempt 4 of ∞. Waiting for 4000ms before trying again.
      Failed to apply EF migrations. Attempt 4 of ∞. Waiting for 4000ms before trying again.
info: GovUk.Education.ManageCourses.Api.Startup[0]
      Applying EF migrations. Attempt 5 of ∞
GovUk.Education.ManageCourses.Api.Startup:Information: Applying EF migrations. Attempt 5 of ∞
Loaded '/usr/share/dotnet/shared/Microsoft.AspNetCore.App/2.1.5/System.Runtime.CompilerServices.Unsafe.dll'. Module was built without symbols.
Loaded '/usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.5/System.Security.Cryptography.Encoding.dll'. Skipped loading symbols. Module is optimized and the debugger option 'Just My Code' is enabled.
Loaded '/usr/share/dotnet/shared/Microsoft.NETCore.App/2.1.5/System.Security.Cryptography.OpenSsl.dll'. Skipped loading symbols. Module is optimized and the debugger option 'Just My Code' is enabled.
info: Microsoft.EntityFrameworkCore.Database.Command[20101]
...
"No migrations were applied. The database is already up to date.","DeveloperMode":"true","AspNetCoreEnvironment":"Development"}}}}
info: GovUk.Education.ManageCourses.Api.Startup[0]
      Applying EF migrations succeeded. Attempt 5 of ∞
GovUk.Education.ManageCourses.Api.Startup:Information: Applying EF migrations succeeded. Attempt 5 of ∞
```