### PR TITLE
Add note on OS specific path separator to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ See: https://github.com/RSuter/NSwag/wiki#ways-to-use-the-toolchain
 
 ## Database Migrations
 
+Watch out for `\` vs `/` in windows / mac / linux. The below are windows-style.
+
+Otherwise you'll get (using windows backslash on linux that expects forwardslash):
+
+    $ dotnet ef --startup-project ..\ManageCourses.Api migrations add wibble
+    MSBUILD : error MSB1009: Project file does not exist.
+    Switch: ..ManageCourses.Api
+    Unable to retrieve project metadata. Ensure it's an MSBuild-based .NET Core project. If you're using custom BaseIntermediateOutputPath or MSBuildProjectExtensionsPath values, Use the --msbuildprojectextensionspath option.
+
 ### Add a migration
 
 Make your changes to the model, then from command prompt:


### PR DESCRIPTION
To help avoid repeat of staring blankly at error message

### Context

Spent some time being confused.

### Changes proposed in this pull request

Readme changes

## Review

preview here https://github.com/DFE-Digital/manage-courses-api/blob/a579e083a0b77998464b67c14ef011adfad11114/README.md#database-migrations