### PR TITLE
Add more fields to Course model for Ucas Importer

### DIFF
--- a/src/ManageCourses.Domain/Migrations/20181212152132_AddMoreUcasFieldsToCourse.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20181212152132_AddMoreUcasFieldsToCourse.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20181212152132_AddMoreUcasFieldsToCourse")]
+    partial class AddMoreUcasFieldsToCourse
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -74,13 +76,13 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
                     b.Property<string>("CourseCode")
                         .HasColumnName("course_code");
 
-                    b.Property<int>("English")
+                    b.Property<int?>("English")
                         .HasColumnName("english");
 
-                    b.Property<string>("HasBeenPublished")
+                    b.Property<bool>("HasBeenPublished")
                         .HasColumnName("has_been_published");
 
-                    b.Property<int>("Maths")
+                    b.Property<int?>("Maths")
                         .HasColumnName("maths");
 
                     b.Property<string>("Modular")
@@ -101,7 +103,7 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
                     b.Property<int>("Qualification")
                         .HasColumnName("qualification");
 
-                    b.Property<int>("Science")
+                    b.Property<int?>("Science")
                         .HasColumnName("science");
 
                     b.Property<DateTime?>("StartDate")

--- a/src/ManageCourses.Domain/Migrations/20181212152132_AddMoreUcasFieldsToCourse.cs
+++ b/src/ManageCourses.Domain/Migrations/20181212152132_AddMoreUcasFieldsToCourse.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class AddMoreUcasFieldsToCourse : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "english",
+                table: "course",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "has_been_published",
+                table: "course",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "maths",
+                table: "course",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "science",
+                table: "course",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "english",
+                table: "course");
+
+            migrationBuilder.DropColumn(
+                name: "has_been_published",
+                table: "course");
+
+            migrationBuilder.DropColumn(
+                name: "maths",
+                table: "course");
+
+            migrationBuilder.DropColumn(
+                name: "science",
+                table: "course");
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -24,6 +24,10 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string ProfpostFlag { get; set; }
         public string Name { get; set; }
         public string Modular { get; set; }
+        public int? English { get; set; }
+        public int? Maths { get; set; }
+        public int? Science { get; set; }
+        public bool HasBeenPublished { get; set; }
 
         public string Subjects => CourseSubjects != null && CourseSubjects.Any() ? string.Join(", ", CourseSubjects.Select(x => x.Subject.SubjectName)) : string.Empty;
         public bool IsSen => CourseSubjects != null && CourseSubjects.Any(x => "U3".Equals(x.Subject.SubjectCode, StringComparison.InvariantCultureIgnoreCase));

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -95,6 +95,10 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
                 returnCourse.ProfpostFlag = organisationCourseRecord.ProfpostFlag;
                 returnCourse.StudyMode = organisationCourseRecord.Studymode;
                 returnCourse.Modular = organisationCourseRecord.Modular;
+                returnCourse.English = organisationCourseRecord.English;
+                returnCourse.Maths = organisationCourseRecord.Maths;
+                returnCourse.Science = organisationCourseRecord.Science;
+                returnCourse.HasBeenPublished = organisationCourseRecord.HasBeenPublished;
                 returnCourse.StartDate = DateTime.TryParse($"{organisationCourseRecord.StartYear} {organisationCourseRecord.StartMonth}", out DateTime startDate) ? (DateTime?) startDate : null;
 
                 returnCourse.CourseSubjects = new Collection<CourseSubject>(courseSubjects.Select(x => new CourseSubject {

--- a/src/ManageCourses.UcasCourseImporter/xls-reader/Domain/UcasCourse.cs
+++ b/src/ManageCourses.UcasCourseImporter/xls-reader/Domain/UcasCourse.cs
@@ -16,9 +16,12 @@ namespace GovUk.Education.ManageCourses.Xls.Domain
         public string Publish { get; set; }
         public string Status { get; set; }
         public string VacStatus { get; set; }
-        public string HasBeenPublished { get; set; }
+        public bool HasBeenPublished { get; set; }
         public string StartYear { get; set; }
         public string StartMonth { get; set; }
         public string Modular { get; set; }
+        public int? English { get; set; }
+        public int? Maths { get; set; }
+        public int? Science { get; set; }
     }
 }

--- a/src/ManageCourses.UcasCourseImporter/xls-reader/XlsReader.cs
+++ b/src/ManageCourses.UcasCourseImporter/xls-reader/XlsReader.cs
@@ -47,6 +47,7 @@ namespace GovUk.Education.ManageCourses.Xls
 
                     var row = sheet.GetRow(dataRowIndex);
                     var accreditingProvider = row.GetCell(columnMap["ACCREDITING_PROVIDER"]).StringCellValue.Trim();
+                    var hasBeenPublished = row.GetCell(columnMap["HAS_BEEN_PUBLISHED"]).StringCellValue.Trim();
                     var ucasCourse = new UcasCourse
                     {
                         InstCode = row.GetCell(columnMap["INST_CODE"]).StringCellValue.Trim(),
@@ -62,10 +63,13 @@ namespace GovUk.Education.ManageCourses.Xls
                         Publish = row.GetCell(columnMap["PUBLISH"]).StringCellValue.Trim(),
                         Status = row.GetCell(columnMap["STATUS"]).StringCellValue.Trim(),
                         VacStatus = row.GetCell(columnMap["VAC_STATUS"]).StringCellValue.Trim(),
-                        HasBeenPublished = row.GetCell(columnMap["HAS_BEEN_PUBLISHED"]).StringCellValue.Trim(),
+                        HasBeenPublished = hasBeenPublished.Equals('Y'),
                         StartYear = row.GetCell(columnMap["YEAR_CODE"]).StringCellValue.Trim(),
                         StartMonth = row.GetCell(columnMap["CRSE_MONTH"]).StringCellValue.Trim(),
-                        Modular = row.GetCell(columnMap["MODULAR"]).StringCellValue.Trim()
+                        Modular = row.GetCell(columnMap["MODULAR"]).StringCellValue.Trim(),
+                        English = ParseIntCell(row.GetCell(columnMap["ENGLISH"]).StringCellValue.Trim()),
+                        Maths = ParseIntCell(row.GetCell(columnMap["MATHS"]).StringCellValue.Trim()),
+                        Science = ParseIntCell(row.GetCell(columnMap["SCIENCE"]).StringCellValue.Trim())
                     };
                     if (!campuses.Any(c => c.InstCode == ucasCourse.InstCode && c.CampusCode == ucasCourse.CampusCode))
                     {
@@ -213,7 +217,7 @@ namespace GovUk.Education.ManageCourses.Xls
         {
             var file = new FileInfo(Path.Combine(folder, CampusFilename));
             _logger.Information("Reading campus xls file from: " + file.FullName);
-            
+
             var skipCount = 0;
             var campuses = new List<UcasCampus>();
             using (var stream = new FileStream(file.FullName, FileMode.Open))
@@ -327,6 +331,20 @@ namespace GovUk.Education.ManageCourses.Xls
             }
             _logger.Information(noteTexts.Count + " note texts loaded from xls");
             return noteTexts;
+        }
+
+        private int? ParseIntCell(string cellValue)
+        {
+            int parsedCell = 0;
+            bool success = int.TryParse(cellValue, out parsedCell);
+
+            int? result = null;
+            if (success)
+            {
+                result = parsedCell;
+            }
+
+            return result;
         }
     }
 }


### PR DESCRIPTION
### Context

These will be used by the prototype Course API.

### Changes proposed in this pull request

- Update Course model
- Create db migration
- Pull in fields using XlsReader
- Pass them along through UcasCourse and Course model

### Guidance to review

`HasBeenPublished` already existed on `UcasCourse` but was not being used as far as I can tell.