### PR TITLE
Fix courses sort order

### DIFF
--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -207,11 +207,13 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                     $"join organisation_user ou on ou.organisation_id = o.id " +
                     $"join \"user\" u on ou.user_id = u.id " +
                     $"where lower(i.provider_code)=lower(@providerCode) " +
-                    $"and lower(u.email)=lower(@email) order by c.name", new NpgsqlParameter("providerCode", providerCode), new NpgsqlParameter("email", email))
+                    $"and lower(u.email)=lower(@email)", new NpgsqlParameter("providerCode", providerCode), new NpgsqlParameter("email", email))
                 .Include(x => x.Provider)
                 .Include(x => x.CourseSubjects).ThenInclude(x => x.Subject)
                 .Include(x => x.AccreditingProvider)
                 .Include(x => x.CourseSites).ThenInclude(x => x.Site)
+                .OrderBy(x => x.Name)//order by doesn't work as part of the sql string
+                                     //it's an ef issue caused by the includes
                 .ToList();
 
             return ucasCourses;

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -35,119 +35,6 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             DataService = new DataService(Context, mockEnrichmentService.Object, mockLogger.Object);
         }
 
-        // [Test]
-        // public void GetOrganisationsShouldReturnData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var result = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     Assert.IsTrue(result.Count == numOrgs);
-        //     Assert.IsTrue(result.All(c => c.TotalCourses == numCourses));
-        // }
-
-        // [Test]
-        // public void GetOrganisationsShouldReturnNoData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var result = DataService.GetOrganisationsForUser("anyone@testing.com").ToList();//try to get the list using an invalid email
-        //     Assert.IsTrue(result.Count == 0);
-        //     Assert.IsTrue(result.All(c => c.TotalCourses == 0));
-        // }
-
-        // [Test]
-        // public void GetOrganisationShouldReturnData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-
-        //     Assert.IsTrue(orgList.Count == numOrgs);
-        //     Assert.IsTrue(orgList.All(c => c.TotalCourses == numCourses));
-
-        //     foreach (var org in orgList)//we have a valid list of data
-        //     {
-        //         var result = DataService.GetOrganisationForUser(TestUserEmail1, org.UcasCode);//get the organisation
-        //         Assert.IsTrue(result.OrganisationName == org.OrganisationName);
-        //     }
-        // }
-
-        // [Test]
-        // public void GetOrganisationShouldReturnNull()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     Assert.IsTrue(orgList.Count == numOrgs);
-        //     Assert.IsTrue(orgList.All(c => c.TotalCourses == numCourses));
-
-        //     foreach (var org in orgList)
-        //     {
-        //         var result = DataService.GetOrganisationForUser("anyone@testing.com", org.UcasCode);//try to get the organisation using an invalid email
-        //         Assert.IsNull(result);
-        //     }
-        // }
-
-        // [Test]
-        // public void GetCoursesShouldReturnData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     Assert.IsTrue(orgList.Count == numOrgs);
-        //     Assert.IsTrue(orgList.All(c => c.TotalCourses == numCourses));
-
-        //     foreach (var org in orgList)
-        //     {
-        //         var result = DataService.GetCourses(TestUserEmail1, org.UcasCode);//get the course for each org
-        //         Assert.AreEqual(numCourses, result.Courses.Count);
-        //     }
-        // }
-        // [Test]
-        // public void GetCoursesShouldReturnStatus()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     orgList.Count.Should().Be(numOrgs);
-
-        //     foreach (var org in orgList)
-        //     {
-        //         var result = DataService.GetCourses(TestUserEmail1, org.UcasCode);//get the course for each org
-
-        //         foreach (var course in result.Courses)
-        //         {
-        //             course.CourseSites.All(s => s.Status == "N").Should().BeTrue();
-        //         }
-        //     }
-        // }
-
-        // [Test]
-        // public void GetCoursesShouldReturnPublish()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     orgList.Count.Should().Be(numOrgs);
-
-        //     foreach (var org in orgList)
-        //     {
-        //         var result = DataService.GetCourses(TestUserEmail1, org.UcasCode);//get the course for each org
-
-        //         foreach (var course in result.Courses)
-        //         {
-        //             course.CourseSites.All(s => s.Publish == "N").Should().BeTrue();
-        //         }
-        //     }
-        // }
-
         [Test]
         [TestCase(null, "")]
         [TestCase("", null)]
@@ -167,29 +54,12 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             Assert.True(result.Count == 0);
         }
 
-        // [Test]
-        // public void GetCoursesWithInvalidUserAndValidUcasCodeShouldNotReturnNoData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     Assert.IsTrue(orgList.Count == numOrgs);
-        //     Assert.IsTrue(orgList.All(c => c.TotalCourses == numCourses));
-
-        //     foreach (var org in orgList)
-        //     {
-        //         var result = DataService.GetCourses("anyone@anywhere.com", org.UcasCode);//get the course for each org
-        //         Assert.True(result.Courses.Count == 0);
-        //     }
-        // }
-
         [Test]
         [TestCase("xxx")]
         [TestCase("   ")]
         [TestCase("")]
         [TestCase(null)]
-        public void GetCoursesWithValidUserAndInvalidProviderCodeShouldNotReturnNoData(string providerCode)
+        public void GetCoursesWithValidUserAndInvalidProviderCodeShouldReturnNoData(string providerCode)
         {
             const int numOrgs = 5;
             const int numCourses = 6;
@@ -199,49 +69,23 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             Assert.True(result.Count == 0);
         }
 
-        // [Test]
-        // public void GetCourseShouldReturnData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     Assert.IsTrue(orgList.Count == numOrgs);
-        //     Assert.IsTrue(orgList.All(c => c.TotalCourses == numCourses));
+        [Test]
+        public void GetCoursesWithValidUserAndProviderCodeShouldReturnOrderedData()
+        {
+            const int numOrgs = 5;
+            const int numCourses = 6;
+            string providerCode = "AB1";
+            LoadData(TestUserEmail1, numOrgs, numCourses, true);
 
-        //     foreach (var org in orgList)
-        //     {
-        //         var coursesList = DataService.GetCourses(TestUserEmail1, org.UcasCode);//get the courses for each org
-        //         foreach (var course in coursesList.Courses)
-        //         {
-        //             var result = DataService.GetCourse(TestUserEmail1, org.UcasCode, course.CourseCode);
-        //             Assert.IsTrue(course != null && result.Name == course.Name);
-        //         }
-        //     }
-        // }
-
-        // [Test]
-        // public void GetCourseWithInvalidUserShouldReturnNoData()
-        // {
-        //     const int numOrgs = 5;
-        //     const int numCourses = 6;
-        //     LoadData(TestUserEmail1, numOrgs, numCourses);
-        //     var orgList = DataService.GetOrganisationsForUser(TestUserEmail1).ToList();
-        //     Assert.IsTrue(orgList.Count == numOrgs);
-        //     Assert.IsTrue(orgList.All(c => c.TotalCourses == numCourses));
-
-        //     foreach (var org in orgList)
-        //     {
-        //         var coursesList = DataService.GetCourses(TestUserEmail1, org.UcasCode);//get the courses for each org
-        //         foreach (var course in coursesList.Courses)
-        //         {
-        //             var result = DataService.GetCourse("someone@somewhere.com", org.UcasCode, course.CourseCode);
-        //             result.Should().BeNull();
-        //         }
-        //     }
-        // }
-
-
+            var result = DataService.GetCoursesForUser(TestUserEmail1, providerCode);//get the course for each org
+            var previousRecordTitleInt = 0;
+            foreach (var course in result)
+            {
+                var recordTitleInt = int.Parse(course.Name.Replace("Title", ""));
+                recordTitleInt.Should().BeGreaterThan(previousRecordTitleInt);
+                previousRecordTitleInt = recordTitleInt;
+            }
+        }
 
         /// <summary>
         /// setup data so we can test
@@ -249,7 +93,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         /// <param name="email">email of the selected user</param>
         /// <param name="numOrgs">number og oganisation records to generate</param>
         /// <param name="numCourses">number of course records to generate</param>
-        private void LoadData(string email, int numOrgs, int numCourses)
+        /// <param name="reverseCourseOrder"></param>
+        private void LoadData(string email, int numOrgs, int numCourses, bool reverseCourseOrder = false)
         {
             Context.Subjects.RemoveRange(Context.Subjects);
             Context.Save();
@@ -275,7 +120,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     ProviderName = "Provider " + counter
                 };
                 Context.Providers.Add(provider);
-                LoadCourses(provider, numCourses, Context.Subjects);
+                LoadCourses(provider, numCourses, Context.Subjects, reverseCourseOrder);
                 Context.OrganisationUsers.Add(new OrganisationUser { User = user, Organisation = org });
                 Context.OrganisationProviders.Add(new OrganisationProvider
                 {
@@ -293,8 +138,10 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         /// <param name="provider">provider code</param>
         /// <param name="numRecords">number of course records to generate</param>
         /// <param name="subjects"></param>
-        private void LoadCourses(Provider provider, int numRecords, IEnumerable<Subject> subjects)
+        /// /// <param name="reverseCourseOrder">flag for listing courses in reverse order for testing order by</param>
+        private void LoadCourses(Provider provider, int numRecords, IEnumerable<Subject> subjects, bool reverseCourseOrder)
         {
+            var reverseCounter = numRecords;
             for (var counter = 1; counter <= numRecords; counter++)
             {
                 var courseCode = "CC" + counter;
@@ -311,7 +158,6 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     LocationName = "Campus " + counter,
                     Provider = provider
                 };
-
                 var course = new Course
                 {
                     AgeRange = "P",
@@ -320,7 +166,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     ProfpostFlag = "PG",
                     ProgramType = "SC",
                     StudyMode = "F",
-                    Name = "Title " + counter,
+                    Name = "Title" + (reverseCourseOrder ? reverseCounter : counter),
                     Provider = provider,
                     CourseSites =  new List<CourseSite>()
                     {
@@ -336,6 +182,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 Context.Sites.Add(site);
 
                 LoadCourseSubjects(course, subjects);
+                reverseCounter--;
             }
         }
 


### PR DESCRIPTION
### Context
This is the bug where courses are not ordered correctly in publish. Here is the card:
https://trello.com/c/XY3YkS5d/800-courses-are-no-longer-ordered-alphabetically-in-publish

### Changes proposed in this pull request
Added sort order to the dbcontext
Added test that would have flushed out this bug
### Guidance to review
The original code had a sort order but this had been over-ridden by the addition of includes that caused ef to ignore the ordering.
The order by has now been moved to the linq in the context.

![image](https://user-images.githubusercontent.com/6573457/51264956-88680380-19af-11e9-850b-141433de51e2.png)

![image](https://user-images.githubusercontent.com/6573457/51265158-09bf9600-19b0-11e9-969f-1941709ecfd3.png)

![image](https://user-images.githubusercontent.com/6573457/51328097-8a42cd00-1a6a-11e9-84be-6163996440b2.png)
