### PR TITLE
Change course site field date

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -114,7 +114,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                     Address = address
                 },
 
-                ApplicationsAcceptedFrom = sites.Select(x => x.ApplicationsAcceptedFrom).Where(x => x != null && x.HasValue)
+                ApplicationsAcceptedFrom = sites.Select(x => x.ApplicationsAcceptedFrom).Where(x => x.HasValue)
                     .OrderBy(x => x.Value)
                     .FirstOrDefault(),
 

--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -114,11 +114,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                     Address = address
                 },
 
-                ApplicationsAcceptedFrom = sites.Select(x =>
-                {
-                    DateTime parsed;
-                    return DateTime.TryParse(x.ApplicationsAcceptedFrom, out parsed) ? (DateTime?)parsed : null;
-                }).Where(x => x != null && x.HasValue)
+                ApplicationsAcceptedFrom = sites.Select(x => x.ApplicationsAcceptedFrom).Where(x => x != null && x.HasValue)
                     .OrderBy(x => x.Value)
                     .FirstOrDefault(),
 

--- a/src/ManageCourses.Domain/Migrations/20190118140611_ChangedCourseSiteFieldDataType.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20190118140611_ChangedCourseSiteFieldDataType.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190118140611_ChangedCourseSiteFieldDataType")]
+    partial class ChangedCourseSiteFieldDataType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20190118140611_ChangedCourseSiteFieldDataType.cs
+++ b/src/ManageCourses.Domain/Migrations/20190118140611_ChangedCourseSiteFieldDataType.cs
@@ -16,10 +16,7 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
 
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            var sql = $"ALTER TABLE \"course_site\" " +
-                      "ALTER COLUMN \"applications_accepted_from\" TYPE text;";
-
-            migrationBuilder.Sql(sql);
+            //There no point of down as when you do go down you need code change therefore another migration
         }
     }
 }

--- a/src/ManageCourses.Domain/Migrations/20190118140611_ChangedCourseSiteFieldDataType.cs
+++ b/src/ManageCourses.Domain/Migrations/20190118140611_ChangedCourseSiteFieldDataType.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class ChangedCourseSiteFieldDataType : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            var sql = $"ALTER TABLE \"course_site\" " +
+                      "ALTER COLUMN \"applications_accepted_from\" " +
+                      "TYPE date USING \"applications_accepted_from\"::date;";
+
+            migrationBuilder.Sql(sql);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            var sql = $"ALTER TABLE \"course_site\" " +
+                      "ALTER COLUMN \"applications_accepted_from\" TYPE text;";
+
+            migrationBuilder.Sql(sql);
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/CourseSite.cs
+++ b/src/ManageCourses.Domain/Models/CourseSite.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace GovUk.Education.ManageCourses.Domain.Models
 {
     public class CourseSite
@@ -5,7 +7,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public int Id { get; set; }
         public Course Course {get; set;} 
         public Site Site {get; set;}         
-        public string ApplicationsAcceptedFrom { get; set; }
+        public DateTime? ApplicationsAcceptedFrom { get; set; }
         public string Status { get; set; }
         public string Publish { get; set; }
         public string VacStatus { get; set; }

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -108,7 +108,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
                 returnCourse.CourseSites = new Collection<CourseSite>(courseRecords.Select(x => new CourseSite
                 {
                     Site = allSites.Single(y => y.Provider?.ProviderCode == x.InstCode && y.Code == x.CampusCode),
-                    ApplicationsAcceptedFrom = DataHelper.GetDateTimeFromString(x.CrseOpenDate),
+                    ApplicationsAcceptedFrom = UcasStringParser.GetDateTimeFromString(x.CrseOpenDate),
                     Status = x.Status,
                     Publish = x.Publish,
                     VacStatus = x.VacStatus

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -108,7 +108,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
                 returnCourse.CourseSites = new Collection<CourseSite>(courseRecords.Select(x => new CourseSite
                 {
                     Site = allSites.Single(y => y.Provider?.ProviderCode == x.InstCode && y.Code == x.CampusCode),
-                    ApplicationsAcceptedFrom = x.CrseOpenDate,
+                    ApplicationsAcceptedFrom = DataHelper.GetDateTimeFromString(x.CrseOpenDate),
                     Status = x.Status,
                     Publish = x.Publish,
                     VacStatus = x.VacStatus

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/DataHelper.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/DataHelper.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
+{
+    public static class DataHelper
+    {
+        public static DateTime? GetDateTimeFromString(string dateToConvert)
+        {
+            if (DateTime.TryParse(dateToConvert, out var returnDate))
+            {
+                return returnDate;
+            }
+            else
+            {
+                return null;
+            }
+        }
+
+    }
+}

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/UcasStringParser.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/UcasStringParser.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
 {
-    public static class DataHelper
+    public static class UcasStringParser
     {
         public static DateTime? GetDateTimeFromString(string dateToConvert)
         {

--- a/tests/ManageCourses.Tests/ImporterTests/Mapping/DataHelperTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/Mapping/DataHelperTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.UcasCourseImporter.Mapping;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.ImporterTests.Mapping
+{
+    [TestFixture]
+    public class DataHelperTests
+    {
+        [Test]
+        [TestCase("")]
+        [TestCase("       ")]
+        [TestCase("invalid date")]
+        [TestCase(null)]
+        public void TestGetDateFromStringReturnsNull(string dateToConvert)
+        {
+            var result = DataHelper.GetDateTimeFromString(dateToConvert);
+            result.Should().BeNull();
+        }
+        [Test]
+        [TestCase("2018-10-16 00:00:00")]
+        [TestCase("2018-10-16")]
+        [TestCase("2018 10 16")]
+        [TestCase("2018/10/16")]
+        public void TestGetDateFromStringReturnsDate(string dateToConvert)
+        {
+            var result = DataHelper.GetDateTimeFromString(dateToConvert);
+            //assert
+            result.Should().NotBeNull();
+            var date = (DateTime) result;
+            date.Day.Should().Be(16);
+            date.Month.Should().Be(10);
+            date.Year.Should().Be(2018);
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/Mapping/UcasStringParserTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/Mapping/UcasStringParserTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace GovUk.Education.ManageCourses.Tests.ImporterTests.Mapping
 {
     [TestFixture]
-    public class DataHelperTests
+    public class UcasStringParserTests
     {
         [Test]
         [TestCase("")]
@@ -17,7 +17,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.Mapping
         [TestCase(null)]
         public void TestGetDateFromStringReturnsNull(string dateToConvert)
         {
-            var result = DataHelper.GetDateTimeFromString(dateToConvert);
+            var result = UcasStringParser.GetDateTimeFromString(dateToConvert);
             result.Should().BeNull();
         }
         [Test]
@@ -27,7 +27,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.Mapping
         [TestCase("2018/10/16")]
         public void TestGetDateFromStringReturnsDate(string dateToConvert)
         {
-            var result = DataHelper.GetDateTimeFromString(dateToConvert);
+            var result = UcasStringParser.GetDateTimeFromString(dateToConvert);
             //assert
             result.Should().NotBeNull();
             var date = (DateTime) result;

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -281,7 +281,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
                             Postcode = "School.PostCode",
                             Code = "SCH"
                         },
-                        ApplicationsAcceptedFrom = "2018-10-16 00:00:00",
+                        ApplicationsAcceptedFrom = DateTime.Parse("2018-10-16 00:00:00"),
                         Status = "r",
                         Publish = publishedCampus ? "Y" : "n",
                         VacStatus="F"
@@ -298,7 +298,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
                                 Postcode = "NotIncludedSchool.PostCode",
                                 Code = "SCHNI"
                             },
-                            ApplicationsAcceptedFrom = "2018-10-16 00:00:00",
+                            ApplicationsAcceptedFrom = DateTime.Parse("2018-10-16 00:00:00"),
                             Status = "d",
                             Publish = publishedCampus ? "Y" : "n",
                             VacStatus="F"


### PR DESCRIPTION
### Context
There is a problem with field in the course_site table in the manage database where a date field is a string instead of a date. Here is the card:
https://trello.com/c/w7kXfqpK/872-fix-datatype-for-applicationsacceptedfrom

### Changes proposed in this pull request
The field has been changed using migrations.
There is also a data helper class to manage the conversion and tests have been added to test this new class.