### PR TITLE
946 add provider last published

### DIFF
--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -122,15 +122,18 @@ namespace GovUk.Education.ManageCourses.Api.Services
                 .OrderByDescending(x => x.Id)
                 .FirstOrDefault();
 
+            var provider = _context.Providers.Single(p => p.ProviderCode == providerCode);
+            var publishTimestamp = DateTime.UtcNow;
+            provider.LastPublishedAt = publishTimestamp;
             if (enrichmentDraftRecord != null)
             {
                 enrichmentDraftRecord.UpdatedAt = DateTime.UtcNow;
                 enrichmentDraftRecord.UpdatedByUser = userOrg.User;
-                enrichmentDraftRecord.LastPublishedAt = DateTime.UtcNow;
+                enrichmentDraftRecord.LastPublishedAt = publishTimestamp;
                 enrichmentDraftRecord.Status = EnumStatus.Published;
-                _context.Save();
                 returnBool = true;
             }
+            _context.Save();
 
             return returnBool;
         }

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -43,6 +43,8 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
             modelBuilder.Entity<Provider>()
                 .HasIndex(ui => ui.ProviderCode)
                 .IsUnique();
+            modelBuilder.Entity<Provider>()
+                .HasIndex(p => p.LastPublishedAt);
 
             modelBuilder.Entity<Subject>()
                 .HasIndex(s => s.SubjectCode)

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -183,11 +183,11 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                     select c.* from course c
                     join provider i on c.provider_id = i.id
                     join organisation_provider oi on oi.provider_id=i.id
-                    join organisation o on o.id = oi.organisation_id 
-                    join organisation_user ou on ou.organisation_id = o.id 
-                    join ""user"" u on u.id = ou.user_id 
-                    where lower(i.provider_code)=lower(@providerCode) 
-                    and lower(c.course_code)=lower(@courseCode) 
+                    join organisation o on o.id = oi.organisation_id
+                    join organisation_user ou on ou.organisation_id = o.id
+                    join ""user"" u on u.id = ou.user_id
+                    where lower(i.provider_code)=lower(@providerCode)
+                    and lower(c.course_code)=lower(@courseCode)
                     and lower(u.email)=lower(@email)", new NpgsqlParameter("providerCode", providerCode), new NpgsqlParameter("courseCode", courseCode), new NpgsqlParameter("email", email))
                 .Include(x => x.Provider)
                 .Include(x => x.CourseSubjects).ThenInclude(x => x.Subject)

--- a/src/ManageCourses.Domain/Migrations/20190208122643_AddProviderLastPublished.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20190208122643_AddProviderLastPublished.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190208122643_AddProviderLastPublished")]
+    partial class AddProviderLastPublished
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20190208122643_AddProviderLastPublished.cs
+++ b/src/ManageCourses.Domain/Migrations/20190208122643_AddProviderLastPublished.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class AddProviderLastPublished : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_published_at",
+                table: "provider",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "last_published_at",
+                table: "provider");
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Migrations/20190208122643_AddProviderLastPublished.cs
+++ b/src/ManageCourses.Domain/Migrations/20190208122643_AddProviderLastPublished.cs
@@ -11,6 +11,9 @@ namespace GovUk.Education.ManageCourses.Domain.Migrations
                 name: "last_published_at",
                 table: "provider",
                 nullable: true);
+            migrationBuilder.Sql(@"
+                update provider set last_published_at = now() at time zone 'utc';
+            ");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/ManageCourses.Domain/Migrations/20190208151134_AddProviderLastPublishedIndex.Designer.cs
+++ b/src/ManageCourses.Domain/Migrations/20190208151134_AddProviderLastPublishedIndex.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace GovUk.Education.ManageCourses.Domain.Migrations
 {
     [DbContext(typeof(ManageCoursesDbContext))]
-    partial class ManageCoursesDbContextModelSnapshot : ModelSnapshot
+    [Migration("20190208151134_AddProviderLastPublishedIndex")]
+    partial class AddProviderLastPublishedIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/ManageCourses.Domain/Migrations/20190208151134_AddProviderLastPublishedIndex.cs
+++ b/src/ManageCourses.Domain/Migrations/20190208151134_AddProviderLastPublishedIndex.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GovUk.Education.ManageCourses.Domain.Migrations
+{
+    public partial class AddProviderLastPublishedIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_provider_last_published_at",
+                table: "provider",
+                column: "last_published_at");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_provider_last_published_at",
+                table: "provider");
+        }
+    }
+}

--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -49,6 +49,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string SchemeMember { get; set; }
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
+        public DateTime? LastPublishedAt { get; set; }
         public string AccreditingProvider { get; set; }
 
         public ICollection<OrganisationProvider> OrganisationProviders { get; set; }

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
@@ -163,6 +163,9 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             publishRecord.Status.Should().BeEquivalentTo(EnumStatus.Published);
             publishRecord.LastPublishedTimestampUtc.Should().NotBeNull();
             publishRecord.EnrichmentModel.RegionCode.Should().Be(RegionCode);
+            var publishedProvider = Context.Providers.Single(p => p.ProviderCode == ProviderInstCode);
+            publishedProvider.LastPublishedAt.Should().BeCloseTo(publishRecord.UpdatedTimestampUtc.Value, 5000);
+
             //test save again after publish
 
             var afterPublishedModel = new UcasProviderEnrichmentPostModel


### PR DESCRIPTION
### Context
The new API for UCAS Apply needs to know what to include for incremental fetches. This field will be used for that.

The test just extends the existing integration test rather than sorting out a unit test because the c# is going away anyway.

### Changes proposed in this pull request
* Add Provider.LastPublishedAt
* Populate existing data with `now()`
* Make the publish button in the publish system update the date in this field.

### Tests done locally
* Ran a migration against a sanitized export from prod, new column was added and populated correctly.
* Fired up api/ui locally, checked that publish button resulted in updated `provider.last_published_at`

### Guidance to review
Run the api which will upgrade your db, check the new col is populated, poke the publish button and check it's updated.