### PR TITLE
[1013] Set course.changed_at

### DIFF
--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -235,6 +235,9 @@ INNER JOIN course_enrichment b on top_id.id = b.id")
             var enrichmentDraftRecord = _context.CourseEnrichments
                 .Where(ie => ie.ProviderCode == providerCode && ie.UcasCourseCode == ucasCourseCode && ie.Status == EnumStatus.Draft).OrderByDescending(x => x.Id).FirstOrDefault();
 
+            var course = _context.Courses.Single(c => c.CourseCode == ucasCourseCode && c.Provider.ProviderCode == providerCode);
+            course.ChangedAt = DateTime.UtcNow; // make sure change shows in incremental fetch api
+
             if (enrichmentDraftRecord != null)
             {
                 enrichmentDraftRecord.UpdatedAt = DateTime.UtcNow;

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -48,6 +48,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 
         public DateTime CreatedAt { get; set; }
         public DateTime UpdatedAt { get; set; }
+        public DateTime ChangedAt { get; set; }
 
         public ICollection<CourseSite> CourseSites { get; set; }
 

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
@@ -24,7 +24,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         private Provider _ucasInstitution;
         private const string ProviderInstCode = "HNY1";
         private const string AccreditingInstCode = "TRILU";
-        private const string UcasCourseCode = "451F";
+        private const string UcasCourseCode = "TK101";
 
         private const string Email = "12345@example.org";
 
@@ -38,7 +38,6 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             Context.Add(accreditingInstitution);
 
             const string providerInstCode = "HNY1";
-            const string crseCode = "TK101";
             _ucasInstitution = new Provider
             {
                 ProviderName = "Honey Lane School", // This is a school so has to have a university accredit the courses it offers
@@ -47,7 +46,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 {
                     new Course
                     {
-                        CourseCode = crseCode,
+                        CourseCode = UcasCourseCode,
                         Name = "Conscious control of telekenisis",
                         AccreditingProvider = accreditingInstitution,
                     }
@@ -158,6 +157,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             var publishRecord = enrichmentService.GetCourseEnrichment(ProviderInstCode.ToLower(), UcasCourseCode, Email);
             publishRecord.Status.Should().BeEquivalentTo(EnumStatus.Published);
             publishRecord.LastPublishedTimestampUtc.Should().NotBeNull();
+            var publishedRecord = Context.Courses.Single(c => c.CourseCode == UcasCourseCode && c.Provider.ProviderCode == ProviderInstCode);
+            publishedRecord.ChangedAt.Should().BeCloseTo(publishRecord.UpdatedTimestampUtc.Value, 5000);
 
             //test save again after publish
             enrichmentService.SaveCourseEnrichment(sourceModel, ProviderInstCode.ToLower(), UcasCourseCode, Email);
@@ -246,7 +247,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         {
             const string aboutCourseText = "About Course Text";
             // Arrange
-            var enrichmentService = new EnrichmentService(Context);            
+            var enrichmentService = new EnrichmentService(Context);
             var dataService = new DataService(Context, enrichmentService, new Mock<ILogger<DataService>>().Object);
             var sourceModel = new CourseEnrichmentModel
             {


### PR DESCRIPTION
To match logic for provider.changed_at

* Bring test course/enrichment codes into line now that we are testing
interaction with the course record.

### Context
Incremental api in https://github.com/DFE-Digital/manage-courses-backend/ requires this field to be set to include modified records.

### Guidance to review

:ship: 