### PR TITLE
1033 filter out opted in providers

### DIFF
--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -53,6 +53,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public DateTime? LastPublishedAt { get; set; }
         public DateTime ChangedAt { get; set; }
         public string AccreditingProvider { get; set; }
+        public bool OptedIn { get; set; }
 
         public ICollection<OrganisationProvider> OrganisationProviders { get; set; }
         public ICollection<Course> Courses { get; set; }

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -17,14 +17,14 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
     public class CourseLoader
     {
         private readonly QualificationMapper qualificationMapper = new QualificationMapper();
-        private Dictionary<string, Provider> allProviders;
+        private readonly IReadOnlyDictionary<string, Provider> _upsertedProviders;
         private readonly List<string> pgdeCourses;
         private readonly Dictionary<string, Subject> allSubjects;
         private readonly IClock _clock;
 
-        public CourseLoader(Dictionary<string, Provider> allProviders, Dictionary<string, Subject> allSubjects, List<PgdeCourse> pgdeCourses, IClock clock)
+        public CourseLoader(IReadOnlyDictionary<string, Provider> upsertedProviders, Dictionary<string, Subject> allSubjects, List<PgdeCourse> pgdeCourses, IClock clock)
         {
-            this.allProviders = allProviders;
+            this._upsertedProviders = upsertedProviders;
             this.pgdeCourses = pgdeCourses.Select(x => x.ProviderCode + "_@@_" + x.CourseCode).ToList();
             this.allSubjects = allSubjects;
             _clock = clock;
@@ -84,12 +84,12 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
 
                 if (!string.IsNullOrWhiteSpace(organisationCourseRecord.AccreditingProvider))
                 {
-                    returnCourse.AccreditingProvider = allProviders[organisationCourseRecord.AccreditingProvider];
+                    returnCourse.AccreditingProvider = _upsertedProviders[organisationCourseRecord.AccreditingProvider];
                 }
 
                 if (!string.IsNullOrWhiteSpace(organisationCourseRecord.InstCode))
                 {
-                    returnCourse.Provider = allProviders[organisationCourseRecord.InstCode];
+                    returnCourse.Provider = _upsertedProviders[organisationCourseRecord.InstCode];
                 }
                 returnCourse.CourseCode = organisationCourseRecord.CrseCode;
                 returnCourse.AgeRange = organisationCourseRecord.Age;

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -17,14 +17,14 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
     public class CourseLoader
     {
         private readonly QualificationMapper qualificationMapper = new QualificationMapper();
-        private readonly IReadOnlyDictionary<string, Provider> _upsertedProviders;
+        private readonly IReadOnlyDictionary<string, Provider> _providerCache;
         private readonly List<string> pgdeCourses;
         private readonly Dictionary<string, Subject> allSubjects;
         private readonly IClock _clock;
 
-        public CourseLoader(IReadOnlyDictionary<string, Provider> upsertedProviders, Dictionary<string, Subject> allSubjects, List<PgdeCourse> pgdeCourses, IClock clock)
+        public CourseLoader(IReadOnlyDictionary<string, Provider> providerCache, Dictionary<string, Subject> allSubjects, List<PgdeCourse> pgdeCourses, IClock clock)
         {
-            this._upsertedProviders = upsertedProviders;
+            _providerCache = providerCache;
             this.pgdeCourses = pgdeCourses.Select(x => x.ProviderCode + "_@@_" + x.CourseCode).ToList();
             this.allSubjects = allSubjects;
             _clock = clock;
@@ -84,12 +84,12 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
 
                 if (!string.IsNullOrWhiteSpace(organisationCourseRecord.AccreditingProvider))
                 {
-                    returnCourse.AccreditingProvider = _upsertedProviders[organisationCourseRecord.AccreditingProvider];
+                    returnCourse.AccreditingProvider = _providerCache[organisationCourseRecord.AccreditingProvider];
                 }
 
                 if (!string.IsNullOrWhiteSpace(organisationCourseRecord.InstCode))
                 {
-                    returnCourse.Provider = _upsertedProviders[organisationCourseRecord.InstCode];
+                    returnCourse.Provider = _providerCache[organisationCourseRecord.InstCode];
                 }
                 returnCourse.CourseCode = organisationCourseRecord.CrseCode;
                 returnCourse.AgeRange = organisationCourseRecord.Age;

--- a/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
@@ -57,20 +57,20 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
                 }
             });
 
-            var allProviders = new Dictionary<string, Provider>();
+            var upsertedProviders = new Dictionary<string, Provider>();
             MigratePerProvider("upsert providers", inst =>
             {
                 var savedProvider = UpsertProvider(ToProvider(inst));
                 _context.Save();
-                allProviders[savedProvider.ProviderCode] = savedProvider;
+                upsertedProviders[savedProvider.ProviderCode] = savedProvider;
             });
 
-            var courseLoader = new CourseLoader(allProviders, allSubjects, pgdeCourses, _clock);
+            var courseLoader = new CourseLoader(upsertedProviders, allSubjects, pgdeCourses, _clock);
 
 
             MigratePerProvider("drop-and-create sites and courses", ucasInst =>
             {
-                var inst = allProviders[ucasInst.InstCode];
+                var inst = upsertedProviders[ucasInst.InstCode];
 
                 DeleteForProvider(inst.ProviderCode);
                 _context.Save();

--- a/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
@@ -61,20 +61,20 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
                 .Include(x => x.Sites)
                 .Include(x => x.Courses)
                 .ToDictionary(p => p.ProviderCode);
-            var upsertedProviders = new Dictionary<string, Provider>();
             MigratePerProvider("upsert providers", providerCache, inst =>
             {
                 var savedProvider = UpsertProvider(ToProvider(inst), providerCache);
                 _context.Save();
-                upsertedProviders[savedProvider.ProviderCode] = savedProvider;
+                // update/add cached copy
+                providerCache[savedProvider.ProviderCode] = savedProvider;
             });
 
-            var courseLoader = new CourseLoader(upsertedProviders, allSubjects, pgdeCourses, _clock);
+            var courseLoader = new CourseLoader(providerCache, allSubjects, pgdeCourses, _clock);
 
 
             MigratePerProvider("drop-and-create sites and courses", providerCache, ucasInst =>
             {
-                var inst = upsertedProviders[ucasInst.InstCode];
+                var inst = providerCache[ucasInst.InstCode];
 
                 DeleteForProvider(inst.ProviderCode);
                 _context.Save();

--- a/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
@@ -125,6 +125,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
             Action<UcasInstitution> action)
         {
             int processed = 0;
+            int skipped = 0;
 
             _logger.Information($"Begin operation \"{operationName}\" on {payload.Institutions.Count()} institutions");
 
@@ -137,6 +138,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
                         if (providerCache.GetValueOrDefault(inst.InstCode)?.OptedIn == true)
                         {
                             _logger.Debug($"Skipped OptedIn provider {inst.InstCode}");
+                            skipped++;
                             continue;
                         }
                         action(inst);
@@ -153,7 +155,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
                     _logger.Information($"Ran operation \"{operationName}\" on {processed} providers so far");
                 }
             }
-            _logger.Information($"Finished operation \"{operationName}\"");
+            _logger.Information($"Finished operation \"{operationName}\". Skipped {skipped} opted-in providers.");
         }
 
         private void MigrateOnce(string operationName, Action action)

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/ProviderBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/ProviderBuilder.cs
@@ -1,0 +1,24 @@
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
+{
+    internal class ProviderBuilder
+    {
+        private readonly Provider _provider;
+
+        public ProviderBuilder()
+        {
+            _provider = new Provider();
+        }
+        public Provider WithCode(string providerCode)
+        {
+            _provider.ProviderCode = providerCode;
+            return _provider;
+        }
+
+        public static implicit operator Provider(ProviderBuilder builder)
+        {
+            return builder._provider;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadBuilder.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using GovUk.Education.ManageCourses.UcasCourseImporter;
+using GovUk.Education.ManageCourses.Xls.Domain;
+
+namespace GovUk.Education.ManageCourses.Tests.ImporterTests.PayloadBuilders
+{
+    internal class PayloadBuilder
+    {
+        private readonly UcasPayload _payload;
+
+        public PayloadBuilder()
+        {
+            _payload = new UcasPayload();
+        }
+
+        public static implicit operator UcasPayload(PayloadBuilder builder)
+        {
+            return builder._payload;
+        }
+
+        public PayloadBuilder WithInstitutions(IEnumerable<UcasInstitution> institutions)
+        {
+            _payload.Institutions = institutions;
+            return this;
+        }
+
+        public PayloadBuilder WithCourses(IEnumerable<UcasCourse> courses)
+        {
+            _payload.Courses = courses;
+            return this;
+        }
+
+        public PayloadBuilder WithCampus(IEnumerable<UcasCampus> campuses)
+        {
+            _payload.Campuses = campuses;
+            return this;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadCampusBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadCampusBuilder.cs
@@ -1,0 +1,37 @@
+using GovUk.Education.ManageCourses.Xls.Domain;
+
+namespace GovUk.Education.ManageCourses.Tests.ImporterTests.PayloadBuilders
+{
+    internal class PayloadCampusBuilder
+    {
+        private readonly UcasCampus _campus;
+
+        public PayloadCampusBuilder()
+        {
+            _campus = new UcasCampus();
+        }
+
+        public static implicit operator UcasCampus(PayloadCampusBuilder builder)
+        {
+            return builder._campus;
+        }
+
+        public PayloadCampusBuilder WithCampusCode(string campusCode)
+        {
+            _campus.CampusCode = campusCode;
+            return this;
+        }
+
+        public PayloadCampusBuilder WithInstCode(string instCode)
+        {
+            _campus.InstCode = instCode;
+            return this;
+        }
+
+        public PayloadCampusBuilder WithRegionCode(int regionCode)
+        {
+            _campus.RegionCode = regionCode;
+            return this;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadCourseBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadCourseBuilder.cs
@@ -1,0 +1,43 @@
+using GovUk.Education.ManageCourses.Xls.Domain;
+
+namespace GovUk.Education.ManageCourses.Tests.ImporterTests.PayloadBuilders
+{
+    internal class PayloadCourseBuilder
+    {
+        private readonly UcasCourse _course;
+
+        public PayloadCourseBuilder()
+        {
+            _course = new UcasCourse();
+        }
+
+        public static implicit operator UcasCourse(PayloadCourseBuilder builder)
+        {
+            return builder._course;
+        }
+
+        public PayloadCourseBuilder WithInstCode(string instCode)
+        {
+            _course.InstCode = instCode;
+            return this;
+        }
+
+        public PayloadCourseBuilder WithCrseCode(string courseCode)
+        {
+            _course.CrseCode = courseCode;
+            return this;
+        }
+
+        public PayloadCourseBuilder WithStatus(string status)
+        {
+            _course.Status = status;
+            return this;
+        }
+
+        public PayloadCourseBuilder WithCampusCode(string campusCode)
+        {
+            _course.CampusCode = campusCode;
+            return this;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadInstitutionBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/PayloadBuilders/PayloadInstitutionBuilder.cs
@@ -1,0 +1,37 @@
+using GovUk.Education.ManageCourses.Xls.Domain;
+
+namespace GovUk.Education.ManageCourses.Tests.ImporterTests.PayloadBuilders
+{
+    internal class PayloadInstitutionBuilder
+    {
+        private readonly UcasInstitution _institution;
+
+        public PayloadInstitutionBuilder()
+        {
+            _institution = new UcasInstitution();
+        }
+
+        public static implicit operator UcasInstitution(PayloadInstitutionBuilder builder)
+        {
+            return builder._institution;
+        }
+
+        public PayloadInstitutionBuilder WithInstCode(string instCode)
+        {
+            _institution.InstCode = instCode;
+            return this;
+        }
+
+        public PayloadInstitutionBuilder WithRegionCode(int regionCode)
+        {
+            _institution.RegionCode = regionCode;
+            return this;
+        }
+
+        public PayloadInstitutionBuilder WithPostcode(string postCode)
+        {
+            _institution.Postcode = postCode;
+            return this;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
@@ -123,21 +123,22 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
         {
             // Arrange
             SaveReferenceDataPayload(Context);
-
-            var optedInProvider = Context.Providers.Add(new Provider{ProviderCode = "optedInProvider", OptedIn = true });
+            var optedInProvider = Context.Providers.Add(new Provider{ProviderCode = "optedInProvider", OptedIn = true }).Entity;
             Context.Save();
 
             var import = GetUcasCoursesPayload();
-
             var courseWithOptedInAccreditingProvider = import.Courses.First();
-            courseWithOptedInAccreditingProvider.AccreditingProvider = "optedInProvider";
+            courseWithOptedInAccreditingProvider.AccreditingProvider = optedInProvider.ProviderCode;
+            var providerWithOptedInAccreditingProvider = import.Institutions.First();
+            providerWithOptedInAccreditingProvider.AccreditingProvider = optedInProvider.ProviderCode;
 
             //Act
             new UcasDataMigrator(Context, new Mock<Serilog.ILogger>().Object, import).UpdateUcasData();
 
             // Assert
             Context.Providers.Where(x => x.OptedIn).Should().HaveCount(1);
-            Context.Courses.Should().HaveCount(1, "valid courses should be re-imported anyway");
+            Context.Courses.Should().HaveCount(1, "course with opted-in accrediting provider should be imported");
+            Context.Providers.Where(p => p.ProviderCode == providerWithOptedInAccreditingProvider.InstCode).Should().HaveCount(1, "provider with opted-in accrediting provider should be imported");
         }
 
         [Test]

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
@@ -8,10 +8,13 @@ using FluentAssertions.Execution;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 using GovUk.Education.ManageCourses.Domain.Models;
 using GovUk.Education.ManageCourses.Tests.DbIntegration;
+using GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders;
+using GovUk.Education.ManageCourses.Tests.ImporterTests.PayloadBuilders;
 using GovUk.Education.ManageCourses.UcasCourseImporter;
 using GovUk.Education.ManageCourses.Xls.Domain;
 using Moq;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 
 namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
 {
@@ -253,20 +256,16 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
 
             };
 
-            var institutions = new List<Provider>
+            var providers = new List<Provider>
             {
-                new Provider {
-                    ProviderCode = InstCode1,
-                },
-                new Provider {
-                    ProviderCode = InstCode2
-                }
+                new ProviderBuilder().WithCode(InstCode1),
+                new ProviderBuilder().WithCode(InstCode2),
             };
 
-            var organisationInstitutions = new List<OrganisationProvider>
+            var organisationProviders = new List<OrganisationProvider>
             {
                 new OrganisationProvider {
-                    Provider = institutions[1],
+                    Provider = providers[1],
                     Organisation = organisations[1],
                 }
             };
@@ -283,42 +282,41 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
 
             context.Users.AddRange(users);
             context.Organisations.AddRange(organisations);
-            context.Providers.AddRange(institutions);
+            context.Providers.AddRange(providers);
             context.OrganisationUsers.AddRange(organisationUsers);
-            context.OrganisationProviders.AddRange(organisationInstitutions);
+            context.OrganisationProviders.AddRange(organisationProviders);
             context.Save();
         }
 
         private static UcasPayload GetUcasCoursesPayload()
         {
-            return new UcasPayload
-            {
-                Institutions = new List<UcasInstitution>
+            const string campusCode = "CMP";
+            return new PayloadBuilder()
+                .WithInstitutions(new List<UcasInstitution>{
+                    new PayloadInstitutionBuilder()
+                        .WithInstCode(InstCode1)
+                        .WithRegionCode(1)
+                        .WithPostcode(InstPostCode1),
+                    new PayloadInstitutionBuilder()
+                        .WithInstCode(InstCode2),
+                    new PayloadInstitutionBuilder()
+                        .WithInstCode(InstCode3),
+                })
+                .WithCourses(new List<UcasCourse>
                 {
-                    new UcasInstitution { InstCode = InstCode1, RegionCode = 1, Postcode = InstPostCode1},
-                    new UcasInstitution { InstCode = InstCode2 },
-                    new UcasInstitution { InstCode = InstCode3 },
-                },
-
-                Courses = new List<UcasCourse>{
-                    new UcasCourse
-                    {
-                        InstCode = InstCode1,
-                        CrseCode = "COURSECODE_1",
-                        Status = "N",
-                        CampusCode = "CMP"
-                    },
-                },
-                Campuses = new List<UcasCampus>
+                    new PayloadCourseBuilder()
+                        .WithInstCode(InstCode1)
+                        .WithCrseCode("COURSECODE_1")
+                        .WithStatus("N")
+                        .WithCampusCode(campusCode),
+                })
+                .WithCampus(new List<UcasCampus>
                 {
-                    new UcasCampus
-                    {
-                        CampusCode = "CMP",
-                        InstCode = InstCode1,
-                        RegionCode = 100
-                    }
-                }
-            };
+                    new PayloadCampusBuilder()
+                        .WithInstCode(InstCode1)
+                        .WithCampusCode(campusCode)
+                        .WithRegionCode(100),
+                });
         }
     }
 }

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
@@ -103,6 +103,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
                 new UcasCourse {InstCode = "DOESNOTEXIST", CrseCode = "FOO"}
             }).ToList();
 
+
             new UcasDataMigrator(Context, new Mock<Serilog.ILogger>().Object, import).UpdateUcasData();
 
             Context.Courses.Should().HaveCount(1, "valid courses should be imported anyway");
@@ -116,6 +117,28 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
             Context.Courses.Should().HaveCount(1, "valid courses should be re-imported anyway");
             Context.Courses.Single().Name.Should().Be("The best title");
             Context.Courses.Single().Provider.Postcode.Should().Be(InstPostCode1);
+        }
+
+        [Test]
+        public void OptedInAccreditingProvider()
+        {
+            // Arrange
+            SaveReferenceDataPayload(Context);
+
+            var optedInProvider = Context.Providers.Add(new Provider{ProviderCode = "optedInProvider", OptedIn = true });
+            Context.Save();
+
+            var import = GetUcasCoursesPayload();
+
+            var courseWithOptedInAccreditingProvider = import.Courses.First();
+            courseWithOptedInAccreditingProvider.AccreditingProvider = "optedInProvider";
+
+            //Act
+            new UcasDataMigrator(Context, new Mock<Serilog.ILogger>().Object, import).UpdateUcasData();
+
+            // Assert
+            Context.Providers.Where(x => x.OptedIn).Should().HaveCount(1);
+            Context.Courses.Should().HaveCount(1, "valid courses should be re-imported anyway");
         }
 
         [Test]

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
@@ -103,7 +103,6 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
                 new UcasCourse {InstCode = "DOESNOTEXIST", CrseCode = "FOO"}
             }).ToList();
 
-
             new UcasDataMigrator(Context, new Mock<Serilog.ILogger>().Object, import).UpdateUcasData();
 
             Context.Courses.Should().HaveCount(1, "valid courses should be imported anyway");


### PR DESCRIPTION
### Context
Gradual migration from UCAS owned provider/course data to DfE owned data.

Update: we now have a circuit breaker in prod to reduce the risk of this change https://github.com/DFE-Digital/search-and-compare-api/pull/132

More test coverage for all the variations of opted in / out etc will be added in a subsequent PR

### Changes proposed in this pull request
* Small refactor
* TDD obeying the provider.opted_in flag in manage_courses database when importing
* Introduce builder pattern to tests in preparation for adding variation in covered scenarios.

### Guidance to review

If this breaks the importer then everything will be on :fire: 
check it carefully, run it locally, convince yourself there are no more edge cases.

To get a distribution of opted in: `update provider set opted_in=true where id % 2 = 0;`