### PR TITLE
Log error for non-timeout issues pushing to find

### DIFF
--- a/src/ManageCourses.CourseExporterUtil/Publisher.cs
+++ b/src/ManageCourses.CourseExporterUtil/Publisher.cs
@@ -53,7 +53,12 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
                 // Still exit cleanly even if the POST failed. The post takes longer than the timeout on the gateway
                 // so we usually get a 502 instead of 200. We have monitoring & alerts in azure so that we will notice
                 // if the receiving end isn't completing its side.
-                _logger.Information($"{nameof(PublishToSearch)} threw, this likely the usual gateway timeout. {ex.Message}");
+                if (ex.Message.Contains("timeout"))
+                {
+                    _logger.Information($"{nameof(PublishToSearch)} threw, this likely the usual gateway timeout. {ex.Message}");
+                    return;
+                }
+                _logger.Error($"{nameof(PublishToSearch)} threw, but didn't seem to be a timeout.", ex);
             }
         }
 


### PR DESCRIPTION
### Context

Can't see the difference between the timeout and a real error.

### Changes proposed in this pull request

Attempt to log non-timeout errors

### Guidance to review

Merge it and test output for timeout on dev. :-D