### PR TITLE
[1133] Add manage_courses_backend__key env var to VSTS

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -156,6 +156,12 @@
             "metadata": {
                 "description": "Connection string for Sentry monitoring."
             }
+        },
+        "manageCoursesBackendKey": {
+            "type": "string",
+            "metadata": {
+                "description": "The secret shared between manage courses backend and manage courses API to authorize requests."
+            }
         }
     },
     "variables": {
@@ -415,6 +421,10 @@
                             {
                                 "name": "SENTRY_DSN",
                                 "value": "[parameters('sentryDSN')]"
+                            },
+                            {
+                                "name": "manage_courses_backend__key",
+                                "value": "[parameters('manageCoursesBackendKey')]"
                             }
                         ]
                     },


### PR DESCRIPTION
### Context

This will be used by manage-courses-backend in order to trigger republishing.

Terraform prior art: https://github.com/DFE-Digital/bat-infrastructure/pull/119

### Guidance to review

I don't understand VSTS very well so don't know if adding this without going and poking the interface to define a value for `manageCoursesBackendKey` will cause everything to break.