### PR TITLE
1274 publish org endpoint

### DIFF
--- a/src/ManageCourses.Api/Controllers/PublishController.cs
+++ b/src/ManageCourses.Api/Controllers/PublishController.cs
@@ -69,6 +69,24 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         }
 
         /// <summary>
+        /// Publishes all of a providers courses
+        /// </summary>
+        /// <returns>boolean indicating success/failure</returns>
+        [HttpPost]
+        [Route("internal/courses/{providerCode}")]
+        [ProducesResponseType(typeof(bool), 200)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(404)]
+        [ExemptFromAcceptTerms]
+        [BackendApiTokenAuth]
+        public async Task<ActionResult> InternalPublishCoursesToSearchAndCompare(string providerCode, [FromBody]BackendRequest request)
+        {
+            var result = await _searchAndCompareService.SaveCourses(providerCode, request.Email);
+
+            return Ok(new{result});
+        }
+
+        /// <summary>
         /// Publishes all courses for an organisation
         /// </summary>
         /// <returns>boolean indicating success/failure</returns>

--- a/src/ManageCourses.Api/Controllers/PublishController.cs
+++ b/src/ManageCourses.Api/Controllers/PublishController.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Api.Data;
 using GovUk.Education.ManageCourses.Api.Mapping;
 using GovUk.Education.ManageCourses.Api.Model;
@@ -70,7 +69,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
         }
 
         /// <summary>
-        /// Publishes all of a providers courses
+        /// Publishes all of a provider's courses
         /// </summary>
         /// <returns>boolean indicating success/failure</returns>
         [HttpPost]

--- a/src/ManageCourses.Api/Controllers/PublishController.cs
+++ b/src/ManageCourses.Api/Controllers/PublishController.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using GovUk.Education.ManageCourses.Api.Data;
 using GovUk.Education.ManageCourses.Api.Mapping;
 using GovUk.Education.ManageCourses.Api.Model;

--- a/tests/ManageCourses.Tests/SmokeTests/ApiBackendPublishCourseTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiBackendPublishCourseTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.ApiClient;
+using NUnit.Framework;
+using System;
+using System.Net;
+using System.Threading.Tasks;
+
+
+namespace GovUk.Education.ManageCourses.Tests.SmokeTests
+{
+    /// <summary>
+    /// These tests poke the http endpoints of the api whilst the api is running in a
+    /// a captive web host.
+    /// </summary>
+    [TestFixture]
+    [Category("Smoke")]
+    [Explicit]
+    public class ApiBackendPublishCourseTests : ApiSmokeTestBase
+    {
+        private const string Email = "feddie.krueger@example.org";
+        private const string ProviderCode = "providerCode";
+        private const string CourseCode = "courseCode";
+
+        /// <summary>
+        ///     Tests a valid http status 200 with result as false, true cannot be tested in this form as it will also make an external call.
+        /// </summary>
+        [Test]
+        public async Task Internal_Publish_PublishCourseToSearchAndCompareAsync()
+        {
+            var client = BuildClient(TestConfig.BackendApiKey);
+
+            var result = await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                ProviderCode, CourseCode, new BackendRequest());
+
+            result.Result.Should().Be(false);
+        }
+
+        [Test]
+        public void Internal_Publish_PublishCourseToSearchAndCompareAsync_internalServerError_500()
+        {
+            var client = BuildClient(TestConfig.BackendApiKey);
+
+            Func<Task> act = async () =>
+                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
+
+            act.Should().Throw<ManageCoursesApiException>()
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        }
+
+        [Test]
+        public void Internal_Publish_PublishCourseToSearchAndCompareAsync_badAccesCode_404()
+        {
+            var client = BuildClient("badAccesCode");
+
+            Func<Task> act = async () =>
+                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
+
+            act.Should().Throw<ManageCoursesApiException>()
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        }
+
+        [Test]
+        public void Internal_Publish_PublishCourseToSearchAndCompareAsync_noAccesCode_401()
+        {
+            var client = BuildClient("");
+
+            Func<Task> act = async () =>
+                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
+
+            act.Should().Throw<ManageCoursesApiException>()
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/SmokeTests/ApiBackendPublishCoursesTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiBackendPublishCoursesTests.cs
@@ -1,18 +1,10 @@
 using FluentAssertions;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.ApiClient;
-using GovUk.Education.ManageCourses.Tests.UnitTesting.Client;
-using GovUk.Education.ManageCourses.Tests.TestUtilities;
-using GovUk.Education.ManageCourses.UcasCourseImporter;
-using Moq;
 using NUnit.Framework;
 using System;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
-using System.Web;
-using Newtonsoft.Json;
-using System.Text;
 
 
 namespace GovUk.Education.ManageCourses.Tests.SmokeTests
@@ -24,11 +16,10 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
     [TestFixture]
     [Category("Smoke")]
     [Explicit]
-    public class BackendInternalApiEndpointTests : ApiSmokeTestBase
+    public class ApiBackendPublishCoursesTests : ApiSmokeTestBase
     {
         private const string Email = "feddie.krueger@example.org";
         private const string ProviderCode = "providerCode";
-        private const string CourseCode = "courseCode";
 
         /// <summary>
         ///     Tests a valid http status 200 with result as false, true cannot be tested in this form as it will also make an external call.
@@ -38,8 +29,8 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             var client = BuildClient(TestConfig.BackendApiKey);
 
-            var result = await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
-                ProviderCode, CourseCode, new BackendRequest());
+            var result = await client.Internal_Publish_PublishCoursesToSearchAndCompareAsync(
+                ProviderCode, new BackendRequest());
 
             result.Result.Should().Be(false);
         }
@@ -50,11 +41,11 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var client = BuildClient(TestConfig.BackendApiKey);
 
             Func<Task> act = async () =>
-                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
-                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
+                await client.Internal_Publish_PublishCoursesToSearchAndCompareAsync(
+                    ProviderCode, new BackendRequest{Email = Email});
 
             act.Should().Throw<ManageCoursesApiException>()
-                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/courses/{ProviderCode}")
                 .Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }
 
@@ -64,11 +55,11 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var client = BuildClient("badAccesCode");
 
             Func<Task> act = async () =>
-                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
-                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
+                await client.Internal_Publish_PublishCoursesToSearchAndCompareAsync(
+                    ProviderCode, new BackendRequest{Email = Email});
 
             act.Should().Throw<ManageCoursesApiException>()
-                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/courses/{ProviderCode}")
                 .Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
@@ -78,11 +69,11 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var client = BuildClient("");
 
             Func<Task> act = async () =>
-                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
-                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
+                await client.Internal_Publish_PublishCoursesToSearchAndCompareAsync(
+                    ProviderCode, new BackendRequest{Email = Email});
 
             act.Should().Throw<ManageCoursesApiException>()
-                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/courses/{ProviderCode}")
                 .Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
     }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiEndpointTests.cs
@@ -1,14 +1,12 @@
 using FluentAssertions;
 using GovUk.Education.ManageCourses.Api.Model;
 using GovUk.Education.ManageCourses.ApiClient;
-using GovUk.Education.ManageCourses.Tests.UnitTesting.Client;
 using GovUk.Education.ManageCourses.Tests.TestUtilities;
 using GovUk.Education.ManageCourses.UcasCourseImporter;
 using Moq;
 using NUnit.Framework;
 using System;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web;
 
@@ -135,10 +133,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             var accessToken = TestConfig.ApiKey;
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new ManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             Context.AddTestReferenceData(Email);
             Context.Save();
@@ -152,10 +147,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             var accessToken = "badAccesCode";
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new ManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             Func<Task> act = async () => await client.Invite_IndexAsync(Email);
 
@@ -172,10 +164,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             const string accessToken = "";
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new ManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             Func<Task> act = async () => await client.Invite_IndexAsync(Email);
 
@@ -202,20 +191,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             var communicator = new DfeSignInCommunicator(TestConfig);
             var accessToken = await communicator.GetAccessToken(TestConfig);
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new ManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
-
-            return client;
-        }
-
-        private ManageCoursesApiClient BuildApiKeyClient(string apiKey = null)
-        {
-            var accessToken = apiKey ?? TestConfig.ApiKey;
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-            var client = new ManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             return client;
         }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -24,9 +24,6 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             LocalWebHost?.Stop();
         }
 
-        /// <summary>
-        /// Backend doesn't use the api client, but it's useful for testing so this class extends the client with methods called backend.
-        /// </summary>
         protected class BackendManageCoursesApiClient : ManageCoursesApiClient
         {
             public BackendManageCoursesApiClient(string apiUrl, IHttpClient httpClient) :base(apiUrl, httpClient)

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -1,5 +1,10 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using GovUk.Education.ManageCourses.Api.Model;
+using GovUk.Education.ManageCourses.ApiClient;
 using GovUk.Education.ManageCourses.Tests.DbIntegration;
 using GovUk.Education.ManageCourses.Tests.TestUtilities;
+using GovUk.Education.ManageCourses.Tests.UnitTesting.Client;
 using NUnit.Framework;
 
 namespace GovUk.Education.ManageCourses.Tests.SmokeTests
@@ -17,6 +22,33 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         public void OneTimeTearDown()
         {
             LocalWebHost?.Stop();
+        }
+
+        /// <summary>
+        /// Backend doesn't use the api client, but it's useful for testing so this class extends the client with methods called backend.
+        /// </summary>
+        protected class BackendManageCoursesApiClient : ManageCoursesApiClient
+        {
+            public BackendManageCoursesApiClient(string apiUrl, IHttpClient httpClient) :base(apiUrl, httpClient)
+            {
+            }
+
+            internal async Task<ResponseResult> Internal_Publish_PublishCourseToSearchAndCompareAsync(string providerCode, string courseCode, BackendRequest request)
+            {
+                return await PostObjects<ResponseResult>($"publish/internal/course/{providerCode}/{courseCode}", request);
+            }
+        }
+
+        protected BackendManageCoursesApiClient BuildClient(string accessToken)
+        {
+            var httpClient = new HttpClient();
+            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
+            return new BackendManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+        }
+
+        internal class ResponseResult
+        {
+            public bool Result {get; set;}
         }
     }
 }

--- a/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ApiSmokeTestBase.cs
@@ -37,6 +37,11 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             {
                 return await PostObjects<ResponseResult>($"publish/internal/course/{providerCode}/{courseCode}", request);
             }
+
+            internal async Task<ResponseResult> Internal_Publish_PublishCoursesToSearchAndCompareAsync(string providerCode, BackendRequest request)
+            {
+                return await PostObjects<ResponseResult>($"publish/internal/courses/{providerCode}", request);
+            }
         }
 
         protected BackendManageCoursesApiClient BuildClient(string accessToken)

--- a/tests/ManageCourses.Tests/SmokeTests/BackendInternalApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/BackendInternalApiEndpointTests.cs
@@ -36,10 +36,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             var accessToken = TestConfig.BackendApiKey;
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new BackendManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             var providerCode = "providerCode";
             var courseCode = "courseCode";
@@ -53,10 +50,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             var accessToken = TestConfig.BackendApiKey;
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new BackendManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             var providerCode = "providerCode";
             var courseCode = "courseCode";
@@ -70,10 +64,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             var accessToken = "badAccesCode";
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new BackendManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             var providerCode = "providerCode";
             var courseCode = "courseCode";
@@ -88,10 +79,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         {
             const string accessToken = "";
 
-            var httpClient = new HttpClient();
-            var httpClientWrapper = new FakeHttpClientWrapper(accessToken, httpClient);
-
-            var client = new BackendManageCoursesApiClient(LocalWebHost.Address, httpClientWrapper);
+            var client = BuildClient(accessToken);
 
             var providerCode = "providerCode";
             var courseCode = "courseCode";
@@ -99,23 +87,6 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 
             var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
             act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Equals(HttpStatusCode.Unauthorized);
-        }
-
-        private class BackendManageCoursesApiClient : ManageCoursesApiClient
-        {
-            public BackendManageCoursesApiClient(string apiUrl, IHttpClient httpClient) :base(apiUrl, httpClient)
-            {
-            }
-
-            internal async Task<ResponseResult> Internal_Publish_PublishCourseToSearchAndCompareAsync(string providerCode, string courseCode, BackendRequest request)
-            {
-                return await PostObjects<ResponseResult>($"publish/internal/course/{providerCode}/{courseCode}", request);
-            }
-        }
-
-        internal class ResponseResult
-        {
-            public bool Result {get; set;}
         }
     }
 }

--- a/tests/ManageCourses.Tests/SmokeTests/BackendInternalApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/BackendInternalApiEndpointTests.cs
@@ -57,7 +57,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             Func<Task> act = async () => await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = Email});
 
             var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
-            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Equals(HttpStatusCode.InternalServerError);
+            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }
         [Test]
         public void Internal_Publish_PublishCourseToSearchAndCompareAsync_badAccesCode_404()
@@ -71,7 +71,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             Func<Task> act = async () => await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = Email});
 
             var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
-            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Equals(HttpStatusCode.NotFound);
+            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [Test]
@@ -86,7 +86,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             Func<Task> act = async () => await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = Email});
 
             var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
-            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Equals(HttpStatusCode.Unauthorized);
+            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
     }
 }

--- a/tests/ManageCourses.Tests/SmokeTests/BackendInternalApiEndpointTests.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/BackendInternalApiEndpointTests.cs
@@ -24,9 +24,11 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
     [TestFixture]
     [Category("Smoke")]
     [Explicit]
-    public partial class BackendInternalApiEndpointTests : ApiSmokeTestBase
+    public class BackendInternalApiEndpointTests : ApiSmokeTestBase
     {
         private const string Email = "feddie.krueger@example.org";
+        private const string ProviderCode = "providerCode";
+        private const string CourseCode = "courseCode";
 
         /// <summary>
         ///     Tests a valid http status 200 with result as false, true cannot be tested in this form as it will also make an external call.
@@ -34,13 +36,10 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [Test]
         public async Task Internal_Publish_PublishCourseToSearchAndCompareAsync()
         {
-            var accessToken = TestConfig.BackendApiKey;
+            var client = BuildClient(TestConfig.BackendApiKey);
 
-            var client = BuildClient(accessToken);
-
-            var providerCode = "providerCode";
-            var courseCode = "courseCode";
-            var result = await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = ""});
+            var result = await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                ProviderCode, CourseCode, new BackendRequest());
 
             result.Result.Should().Be(false);
         }
@@ -48,45 +47,43 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
         [Test]
         public void Internal_Publish_PublishCourseToSearchAndCompareAsync_internalServerError_500()
         {
-            var accessToken = TestConfig.BackendApiKey;
+            var client = BuildClient(TestConfig.BackendApiKey);
 
-            var client = BuildClient(accessToken);
+            Func<Task> act = async () =>
+                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
 
-            var providerCode = "providerCode";
-            var courseCode = "courseCode";
-            Func<Task> act = async () => await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = Email});
-
-            var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
-            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+            act.Should().Throw<ManageCoursesApiException>()
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .Which.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
         }
+
         [Test]
         public void Internal_Publish_PublishCourseToSearchAndCompareAsync_badAccesCode_404()
         {
-            var accessToken = "badAccesCode";
+            var client = BuildClient("badAccesCode");
 
-            var client = BuildClient(accessToken);
+            Func<Task> act = async () =>
+                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
 
-            var providerCode = "providerCode";
-            var courseCode = "courseCode";
-            Func<Task> act = async () => await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = Email});
-
-            var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
-            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
+            act.Should().Throw<ManageCoursesApiException>()
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .Which.StatusCode.Should().Be(HttpStatusCode.NotFound);
         }
 
         [Test]
         public void Internal_Publish_PublishCourseToSearchAndCompareAsync_noAccesCode_401()
         {
-            const string accessToken = "";
+            var client = BuildClient("");
 
-            var client = BuildClient(accessToken);
+            Func<Task> act = async () =>
+                await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(
+                    ProviderCode, CourseCode, new BackendRequest{Email = Email});
 
-            var providerCode = "providerCode";
-            var courseCode = "courseCode";
-            Func<Task> act = async () => await client.Internal_Publish_PublishCourseToSearchAndCompareAsync(providerCode, courseCode, new BackendRequest{Email = Email});
-
-            var msg = $"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{providerCode}/{courseCode}";
-            act.Should().Throw<ManageCoursesApiException>().WithMessage(msg).Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+            act.Should().Throw<ManageCoursesApiException>()
+                .WithMessage($"API POST Failed uri {LocalWebHost.Address}/api/publish/internal/course/{ProviderCode}/{CourseCode}")
+                .Which.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
     }
 }


### PR DESCRIPTION
### Context

For the new location editing that's coming up
https://manage-courses-prototype.herokuapp.com/location/-

We can't use the existing internal-publish endpoint because it
only does one course, which means site info would be stale.

The new endpoint does a subset of the work that
`PublishCoursesToSearchAndCompare()` does

This change is similar to https://github.com/DFE-Digital/manage-courses-api/commit/ca55908506fd100293793af91b42bd938f616e27#diff-88577f484b6f5060edc3361bd633642aR59

### Changes proposed in this pull request

* Refactor existing backend test for brevity
* Fix assertion mistake in existing tests (`.Should().Be` instead of `Equals`)
* Renamed existing test class so that pair of test files will look right in file listing
* Add new endpoint to controller
* Duplicate existing backend regression test for new endpoint - this tests that service is actually called, which should be enough regression proofing against unknowingly breaking the endpoint in the future.

### Guidance to review

:ship: 
