### PR TITLE
[1583] Prevent publishing of courses with no published sites

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -16,6 +16,13 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
 
         public SearchAndCompare.Domain.Models.Course MapToSearchAndCompareCourse(Domain.Models.Provider ucasProviderData, Domain.Models.Course ucasCourseData, ProviderEnrichmentModel providerEnrichmentModel, CourseEnrichmentModel courseEnrichmentModel)
         {
+            // if none of the course-sites are published, return null to prevent the whole course from being published to find
+            if (ucasCourseData?.CourseSites == null || ucasCourseData.CourseSites.All(cs =>
+                    !cs.Publish.Equals("Y", StringComparison.InvariantCultureIgnoreCase)))
+            {
+                return null; // don't allow publishing unpublished courses to find
+            }
+
             ucasProviderData = ucasProviderData ?? new Domain.Models.Provider();
             ucasCourseData = ucasCourseData ?? new Domain.Models.Course();
             var sites = ucasCourseData.CourseSites ?? new ObservableCollection<CourseSite>();

--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -16,9 +16,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
 
         public SearchAndCompare.Domain.Models.Course MapToSearchAndCompareCourse(Domain.Models.Provider ucasProviderData, Domain.Models.Course ucasCourseData, ProviderEnrichmentModel providerEnrichmentModel, CourseEnrichmentModel courseEnrichmentModel)
         {
-            // if none of the course-sites are published, return null to prevent the whole course from being published to find
-            if (ucasCourseData?.CourseSites == null || ucasCourseData.CourseSites.All(cs =>
-                    !cs.Publish.Equals("Y", StringComparison.InvariantCultureIgnoreCase)))
+            if (ucasCourseData == null || !ucasCourseData.IsPublished)
             {
                 return null; // don't allow publishing unpublished courses to find
             }

--- a/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
+++ b/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
@@ -64,6 +64,9 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
             return await SaveImplementation(courses, providerCode);
         }
 
+        /// <summary>
+        /// Get all the courses that are ready to publish to find
+        /// </summary>
         private List<Course> GetValidCourses(string providerCode, string email, string courseCode = null)
         {
             var ucasProviderData = _dataService.GetProviderForUser(email, providerCode);
@@ -82,7 +85,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
                     .Select(x => GetCourse(providerCode, x.CourseCode, email, ucasProviderData, orgEnrichmentData)));
             }
 
-            return courses.Where(courseToSave => courseToSave.IsValid(false)).ToList();
+            return courses.Where(courseToSave => courseToSave != null && courseToSave.IsValid(false)).ToList();
         }
 
         private async Task<bool> SaveImplementation(IList<Course> courses, string providerCode)
@@ -109,6 +112,9 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
             return true;
         }
 
+        /// <summary>
+        /// Map manage courses course into find course, combining in enrichment data.
+        /// </summary>
         private Course GetCourse(string providerCode, string courseCode, string email, Provider ucasProviderData, UcasProviderEnrichmentGetModel orgEnrichmentData)
         {
             var ucasCourseData = _dataService.GetCourseForUser(email, providerCode, courseCode);

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -73,6 +73,16 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         [NotMapped]
         public bool HasVacancies { get => CourseSites?.Any(s => s.VacStatus == "B" || s.VacStatus == "F" || s.VacStatus == "P") ?? false;}
 
+        [NotMapped]
+        public bool IsPublished
+        {
+            get
+            {
+                return CourseSites != null &&
+                       CourseSites.Any(cs =>
+                           cs.Publish.Equals("Y", StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
 
         private string GetCourseVariantType()
         {

--- a/tests/ManageCourses.Tests/SmokeTests/TestPayloadBuilder.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/TestPayloadBuilder.cs
@@ -14,7 +14,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
                     InstFull = "Joe's school @ UCAS",
                     InstCode = "ABC"
                 }),
-                            
+
                 Campuses = ListOfOne(new UcasCampus {
                     InstCode = "ABC",
                     CampusCode = "", // NOTE: EMPTY STRING
@@ -25,11 +25,12 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
                     InstCode = "ABC",
                     CampusCode = "",
                     CrseCode = "XYZ",
-                    CrseTitle = "Joe's course for Primary teachers"
+                    CrseTitle = "Joe's course for Primary teachers",
+                    Publish = "Y",
                 })
             };
-        
-        
+
+
         private static List<T> ListOfOne<T> (T one) {
             return new List<T> { one };
         }

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -127,44 +127,11 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         {
             var res = mapper.MapToSearchAndCompareCourse(
                 GenerateUcasProvider(),
-                GenerateUcasCourse(),
+                GenerateUcasCourse(publishedCampus: false),
                 GenerateProviderEnrichmentWithoutContactDetails(),
                 GenerateCourseEnrichmentModel()
             );
-
-            res.Duration.Should().Be("1 year");
-            res.Name.Should().Be("Course.Name");
-            res.ProgrammeCode.Should().Be("CourseCode");
-
-            res.Provider.ProviderCode.Should().Be("ABC");
-            res.Provider.Name.Should().Be("My provider");
-            res.AccreditingProvider.ProviderCode.Should().Be("ACC123");
-            res.AccreditingProvider.Name.Should().Be("AccreditingProviderName");
-
-            res.Route.Name.Should().Be("School Direct (salaried) training programme");
-            res.Route.IsSalaried.Should().Be(true);
-
-            res.IncludesPgce.Should().Be(SearchAndCompare.Domain.Models.Enums.IncludesPgce.Yes);
-            res.IsSalaried.Should().BeTrue();
-
-            res.Campuses.Count.Should().Be(0);
-
-            res.CourseSubjects.Count.Should().Be(2);
-            res.CourseSubjects.Any(x => x.Subject.Name == "Mathematics").Should().BeTrue();
-            res.CourseSubjects.Any(x => x.Subject.Name == "Physics").Should().BeTrue();
-
-            res.Fees.Uk.Should().Be(123);
-            res.Fees.Eu.Should().Be(123);
-            res.Fees.International.Should().Be(123000);
-
-            res.ContactDetails.Website.Should().Be("http://www.example.com");
-            res.ContactDetails.Address.Should().Be("Addr1\nAddr2\nAddr3\nAddr4\nPostcode");
-
-            res.ApplicationsAcceptedFrom.Should().Be(new System.DateTime(2018, 10, 16));
-
-            res.FullTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);
-            res.PartTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);
-            res.IsSen.Should().BeFalse();
+            res.Should().BeNull();
         }
 
         [Test]
@@ -252,7 +219,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             };
         }
 
-        private static Course GenerateUcasCourse(bool publishedCampus = false)
+        private static Course GenerateUcasCourse(bool publishedCampus = true)
         {
             return new Course
             {

--- a/tests/ManageCourses.Tests/UnitTesting/Model/CourseTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/Model/CourseTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.Domain.Models;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Model
+{
+    [TestFixture]
+    public class CourseTests
+    {
+        [Test]
+        public void IsPublished_NullSites()
+        {
+            var course = new Course
+            {
+                CourseSites = null,
+            };
+            course.IsPublished.Should().BeFalse();
+        }
+
+        [Test]
+        public void IsPublished_NoSites()
+        {
+            var course = new Course
+            {
+                CourseSites = new List<CourseSite>(),
+            };
+            course.IsPublished.Should().BeFalse();
+        }
+
+        [Test]
+        public void IsPublished_UnpublishedSites()
+        {
+            var course = new Course
+            {
+                CourseSites = new List<CourseSite>
+                {
+                    new CourseSite
+                    {
+                        Publish = "N",
+                    }
+                },
+            };
+            course.IsPublished.Should().BeFalse();
+        }
+
+        [Test]
+        public void IsPublished_PublishedSites()
+        {
+            var course = new Course
+            {
+                CourseSites = new List<CourseSite>
+                {
+                    new CourseSite
+                    {
+                        Publish = "Y",
+                    }
+                },
+            };
+            course.IsPublished.Should().BeTrue();
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
@@ -47,18 +47,19 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         public void PublishEnrichedCourseWithEmailHappyPathTest()
         {
             var email = "tester@example.com";
+            var course = MakePublishedCourse();
+
             Provider provider = new Provider
             {
                 ProviderCode = ProviderCode,
-                AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
+                AccreditedCourses = new List<Course> { course }
             };
+
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
-            _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))
-                .Returns(new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" });
+            _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode)).Returns(course);
 
             _dataServiceMock.Setup(x => x.GetCoursesForUser(email, ProviderCode))
-                .Returns(new List<Course>{ new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" } } );
+                .Returns(new List<Course>{ course } );
 
             _enrichmentServiceMock.Setup(x => x.GetProviderEnrichmentForPublish(ProviderCode, email))
                 .Returns(new UcasProviderEnrichmentGetModel{EnrichmentModel = new ProviderEnrichmentModel()});
@@ -77,26 +78,50 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             result.Should().BeTrue();
             _httpMock.VerifyAll();
         }
+
+        private static Course MakePublishedCourse()
+        {
+            return new Course
+            {
+                CourseCode = CourseCode,
+                ProgramType = "SD",
+                CourseSites = new List<CourseSite>
+                {
+                    new CourseSite
+                    {
+                        Publish = "Y",
+                    },
+                },
+                CourseSubjects = new List<CourseSubject>
+                {
+                    new CourseSubject { Subject = new Subject { SubjectName = "History"}}
+                },
+                Name = "History"
+            };
+        }
+
         [Test]
         public void PublishEnrichedCoursesWithEmailHappyPathTest()
         {
             var email = "tester@example.com";
+            var course = MakePublishedCourse();
             var provider = new Provider
             {
                 ProviderCode = ProviderCode,
                 AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
+                    new List<Course> {course}
             };
 
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))
-                .Returns(new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" });
+                .Returns(course);
 
+            var course1 = new Course { CourseCode = CourseCode + "1", Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "Geography"}}}, Name = "Geography" };
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode + "1"))
-                .Returns(new Course { CourseCode = CourseCode + "1", Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "Geography"}}}, Name = "Geography" });
+                .Returns(course1);
 
             _dataServiceMock.Setup(x => x.GetCoursesForUser(email, ProviderCode))
-                .Returns(new List<Course> { new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" }, new Course { CourseCode = CourseCode + "1", Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "Geography"}}}, Name = "History" } } );
+                .Returns(new List<Course> { course, new Course { CourseCode = CourseCode + "1", Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "Geography"}}}, Name = "History" } } );
 
             _enrichmentServiceMock.Setup(x => x.GetProviderEnrichmentForPublish(ProviderCode, email))
                 .Returns(new UcasProviderEnrichmentGetModel { EnrichmentModel = new ProviderEnrichmentModel() });


### PR DESCRIPTION
### Context

The code for preventing this currently lives in the sc-exporter:
https://github.com/DFE-Digital/manage-courses-api/blob/5cf6af07263c3090a8de8ff528f979756da49c8f/src/ManageCourses.CourseExporterUtil/Publisher.cs#L92

Now that the mcb tool is looping through the courses for a provider it
wasn't hitting this filter and was over-publishing to find.

### Changes proposed in this pull request

Skip courses with no published sites when publishing

