### PR TITLE
[1583] Refine failure modes for publishing unpublished courses

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -16,11 +16,6 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
 
         public SearchAndCompare.Domain.Models.Course MapToSearchAndCompareCourse(Domain.Models.Provider ucasProviderData, Domain.Models.Course ucasCourseData, ProviderEnrichmentModel providerEnrichmentModel, CourseEnrichmentModel courseEnrichmentModel)
         {
-            if (ucasCourseData == null || !ucasCourseData.IsPublished)
-            {
-                return null; // don't allow publishing unpublished courses to find
-            }
-
             ucasProviderData = ucasProviderData ?? new Domain.Models.Provider();
             ucasCourseData = ucasCourseData ?? new Domain.Models.Course();
             var sites = ucasCourseData.CourseSites ?? new ObservableCollection<CourseSite>();
@@ -92,8 +87,10 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                 },
                 IncludesPgce = MapQualification(ucasCourseData.Qualification),
                 HasVacancies = ucasCourseData.HasVacancies,
-                Campuses = new Collection<SearchAndCompare.Domain.Models.Campus>(sites
-                    .Where(school => String.Equals(school.Status, "r", StringComparison.InvariantCultureIgnoreCase) && String.Equals(school.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
+                Campuses = new Collection<SearchAndCompare.Domain.Models.Campus>(
+                    sites
+                    .Where(courseSite => String.Equals(courseSite.Status, "r", StringComparison.InvariantCultureIgnoreCase)
+                                         && String.Equals(courseSite.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
                     .Select(school =>
                         new SearchAndCompare.Domain.Models.Campus
                         {

--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
         {
             ucasProviderData = ucasProviderData ?? new Domain.Models.Provider();
             ucasCourseData = ucasCourseData ?? new Domain.Models.Course();
-            var sites = ucasCourseData.CourseSites ?? new ObservableCollection<CourseSite>();
+            var sites = ucasCourseData.PublishableSites.ToList();
             providerEnrichmentModel = providerEnrichmentModel ?? new ProviderEnrichmentModel();
             courseEnrichmentModel = courseEnrichmentModel ?? new CourseEnrichmentModel();
 
@@ -89,8 +89,6 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                 HasVacancies = ucasCourseData.HasVacancies,
                 Campuses = new Collection<SearchAndCompare.Domain.Models.Campus>(
                     sites
-                    .Where(courseSite => String.Equals(courseSite.Status, "r", StringComparison.InvariantCultureIgnoreCase)
-                                         && String.Equals(courseSite.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
                     .Select(school =>
                         new SearchAndCompare.Domain.Models.Campus
                         {

--- a/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
+++ b/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
@@ -82,10 +82,11 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
             if (courseCode != null)
             {
                 courses = new List<Course> { GetCourse(providerCode, courseCode, email, ucasProviderData, orgEnrichmentData) };
-
+                _logger.LogInformation($"GetValidCourses for provider '{providerCode}' course code '{courseCode}';");
             }
             else
             {
+                _logger.LogInformation($"GetValidCourses for provider '{providerCode}'");
                 courses.AddRange(_dataService.GetCoursesForUser(email, providerCode)
                     .Select(x => GetCourse(providerCode, x.CourseCode, email, ucasProviderData, orgEnrichmentData)));
             }
@@ -126,7 +127,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
             var ucasCourseData = _dataService.GetCourseForUser(email, providerCode, courseCode);
             var courseEnrichmentData = _enrichmentService.GetCourseEnrichmentForPublish(providerCode, courseCode, email);
 
-            if (!ucasCourseData.IsPublished)
+            if (!ucasCourseData.PublishableSites.Any())
             {
                 return null;
             }

--- a/src/ManageCourses.CourseExporterUtil/Publisher.cs
+++ b/src/ManageCourses.CourseExporterUtil/Publisher.cs
@@ -131,7 +131,7 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
                     converter.Convert(courseEnrichments.GetValueOrDefault(c.Provider.ProviderCode + "_@@_" + c.CourseCode))?.EnrichmentModel
                 );
 
-                if (!mappedCourse.Campuses.Any())
+                if (mappedCourse == null || !mappedCourse.Campuses.Any())
                 {
                     // only publish running courses
                     continue;

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -74,13 +74,14 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public bool HasVacancies { get => CourseSites?.Any(s => s.VacStatus == "B" || s.VacStatus == "F" || s.VacStatus == "P") ?? false;}
 
         [NotMapped]
-        public bool IsPublished
+        public IEnumerable<CourseSite> PublishableSites
         {
             get
             {
-                return CourseSites != null &&
-                       CourseSites.Any(cs =>
-                           cs.Publish.Equals("Y", StringComparison.InvariantCultureIgnoreCase));
+                return CourseSites?.Where(courseSite =>
+                    string.Equals(courseSite.Status, "r", StringComparison.InvariantCultureIgnoreCase)
+                    && string.Equals(courseSite.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
+                    ?? new List<CourseSite>();
             }
         }
 

--- a/tests/ManageCourses.Tests/ManageCourses.Tests.csproj
+++ b/tests/ManageCourses.Tests/ManageCourses.Tests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ManageCourses.Api\ManageCourses.Api.csproj" />
@@ -32,6 +33,10 @@
   </ItemGroup>
   <ItemGroup>
     <Content Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="appsettings.json">
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -160,7 +160,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             res.ContactDetails.Website.Should().Be("http://www.example.com");
             res.ContactDetails.Address.Should().Be("Addr1\nAddr2\nAddr3\nAddr4\nPostcode");
 
-            res.ApplicationsAcceptedFrom.Should().Be(new System.DateTime(2018, 10, 16));
+            res.ApplicationsAcceptedFrom.Should().BeNull();
 
             res.FullTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);
             res.PartTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -127,11 +127,44 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         {
             var res = mapper.MapToSearchAndCompareCourse(
                 GenerateUcasProvider(),
-                GenerateUcasCourse(publishedCampus: false),
+                GenerateUcasCourse(),
                 GenerateProviderEnrichmentWithoutContactDetails(),
                 GenerateCourseEnrichmentModel()
             );
-            res.Should().BeNull();
+
+            res.Duration.Should().Be("1 year");
+            res.Name.Should().Be("Course.Name");
+            res.ProgrammeCode.Should().Be("CourseCode");
+
+            res.Provider.ProviderCode.Should().Be("ABC");
+            res.Provider.Name.Should().Be("My provider");
+            res.AccreditingProvider.ProviderCode.Should().Be("ACC123");
+            res.AccreditingProvider.Name.Should().Be("AccreditingProviderName");
+
+            res.Route.Name.Should().Be("School Direct (salaried) training programme");
+            res.Route.IsSalaried.Should().Be(true);
+
+            res.IncludesPgce.Should().Be(SearchAndCompare.Domain.Models.Enums.IncludesPgce.Yes);
+            res.IsSalaried.Should().BeTrue();
+
+            res.Campuses.Count.Should().Be(0);
+
+            res.CourseSubjects.Count.Should().Be(2);
+            res.CourseSubjects.Any(x => x.Subject.Name == "Mathematics").Should().BeTrue();
+            res.CourseSubjects.Any(x => x.Subject.Name == "Physics").Should().BeTrue();
+
+            res.Fees.Uk.Should().Be(123);
+            res.Fees.Eu.Should().Be(123);
+            res.Fees.International.Should().Be(123000);
+
+            res.ContactDetails.Website.Should().Be("http://www.example.com");
+            res.ContactDetails.Address.Should().Be("Addr1\nAddr2\nAddr3\nAddr4\nPostcode");
+
+            res.ApplicationsAcceptedFrom.Should().Be(new System.DateTime(2018, 10, 16));
+
+            res.FullTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);
+            res.PartTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);
+            res.IsSen.Should().BeFalse();
         }
 
         [Test]
@@ -219,7 +252,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             };
         }
 
-        private static Course GenerateUcasCourse(bool publishedCampus = true)
+        private static Course GenerateUcasCourse(bool publishedCampus = false)
         {
             return new Course
             {

--- a/tests/ManageCourses.Tests/UnitTesting/Model/CourseTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/Model/CourseTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using FluentAssertions;
 using GovUk.Education.ManageCourses.Domain.Models;
 using NUnit.Framework;
@@ -9,27 +10,45 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Model
     public class CourseTests
     {
         [Test]
-        public void IsPublished_NullSites()
+        public void PublishableSites_NullSites()
         {
             var course = new Course
             {
                 CourseSites = null,
             };
-            course.IsPublished.Should().BeFalse();
+            course.PublishableSites.Should().HaveCount(0);
         }
 
         [Test]
-        public void IsPublished_NoSites()
+        public void PublishableSites_NoSites()
         {
             var course = new Course
             {
                 CourseSites = new List<CourseSite>(),
             };
-            course.IsPublished.Should().BeFalse();
+            course.PublishableSites.Should().HaveCount(0);
         }
 
         [Test]
-        public void IsPublished_UnpublishedSites()
+        // uppercase
+        [TestCase("N", "N", false)]
+        [TestCase("R", "N", false)]
+        [TestCase("S", "N", false)]
+        [TestCase("D", "N", false)]
+        [TestCase("N", "Y", false)]
+        [TestCase("R", "Y", true)]
+        [TestCase("S", "Y", false)]
+        [TestCase("D", "Y", false)]
+        // lowercase
+        [TestCase("n", "n", false)]
+        [TestCase("r", "n", false)]
+        [TestCase("s", "n", false)]
+        [TestCase("d", "n", false)]
+        [TestCase("n", "y", false)]
+        [TestCase("r", "y", true)]
+        [TestCase("s", "y", false)]
+        [TestCase("d", "y", false)]
+        public void PublishableSites_UnpublishedSites(string status, string publish, bool publishable)
         {
             var course = new Course
             {
@@ -37,27 +56,12 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Model
                 {
                     new CourseSite
                     {
-                        Publish = "N",
+                        Status = status,
+                        Publish = publish,
                     }
                 },
             };
-            course.IsPublished.Should().BeFalse();
-        }
-
-        [Test]
-        public void IsPublished_PublishedSites()
-        {
-            var course = new Course
-            {
-                CourseSites = new List<CourseSite>
-                {
-                    new CourseSite
-                    {
-                        Publish = "Y",
-                    }
-                },
-            };
-            course.IsPublished.Should().BeTrue();
+            course.PublishableSites.Should().HaveCount(publishable ? 1 : 0);
         }
     }
 }

--- a/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
@@ -89,7 +89,9 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
                 {
                     new CourseSite
                     {
+                        Status = "R",
                         Publish = "Y",
+                        Site = new Site(),
                     },
                 },
                 CourseSubjects = new List<CourseSubject>

--- a/tests/ManageCourses.Tests/appsettings.json
+++ b/tests/ManageCourses.Tests/appsettings.json
@@ -1,0 +1,29 @@
+﻿{
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.Trace" ],
+    "MinimumLevel": {
+      "Default": "Information",
+      "Override": {
+        "Microsoft": "Error",
+        "System": "Error"
+      }
+    },
+    "WriteTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:o} {Level:u3} {SourceContext:000}] {Message:lj} {NewLine}{Exception}"
+        }
+      },
+      {
+        "Name": "Trace",
+        "Args": {
+          "outputTemplate": "[{Timestamp:o} {Level:u3} {SourceContext:000}] {Message:lj} {NewLine}{Exception}"
+        }
+      }
+    ],
+    "Enrich": [ "FromLogContext" ]
+  },
+  "MANAGE_COURSES_POSTGRESQL_SERVICE_HOST":"localhost",
+  "PG_DATABASE":"manage_courses"
+}


### PR DESCRIPTION

### Context

* sc-exporter is falling over on newly introduced nulls (not hit prod yet)
* preview possibly broken by introducing null return


### Changes proposed in this pull request

* revert change to course mapper that introduced nulls
* check for unpublished course only in publish endpoint flow

### Guidance to review

Don't ask about the tests.

### Commit message

The original patch to make the mapper return null broke other usages of
the mapper (bulk export & preview).

This second attempt operates in the publish controller instead. It still
causes attempts to publish a single course that is not published to fail
(which was the intent of the previous PR), but will leave all other code
paths untouched.

* Revert returning null in mapper
* Return null `GetValidCourses()` instead so that the publish controller
can decide what to do with non-published courses
* In the case of a request to publish a single course, fail (return
false) if null was returned from GetValidCourses.
* I think this changes the behaviour of publishing an entire provider to
only publish published courses. This might previously have been
incorrect.
* Revert tests as original mapper behaviour has been restored.
* Make sc-exporter cope with any nulls returned from course mapper

