### PR TITLE
[1583] Only publish courses with running & published site(s)

### DIFF
--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -18,7 +18,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
         {
             ucasProviderData = ucasProviderData ?? new Domain.Models.Provider();
             ucasCourseData = ucasCourseData ?? new Domain.Models.Course();
-            var sites = ucasCourseData.CourseSites ?? new ObservableCollection<CourseSite>();
+            var courseSites = ucasCourseData.PublishableSites ?? new ObservableCollection<CourseSite>();
             providerEnrichmentModel = providerEnrichmentModel ?? new ProviderEnrichmentModel();
             courseEnrichmentModel = courseEnrichmentModel ?? new CourseEnrichmentModel();
 
@@ -87,8 +87,8 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                 },
                 IncludesPgce = MapQualification(ucasCourseData.Qualification),
                 HasVacancies = ucasCourseData.HasVacancies,
-                Campuses = new Collection<SearchAndCompare.Domain.Models.Campus>(sites
-                    .Where(school => String.Equals(school.Status, "r", StringComparison.InvariantCultureIgnoreCase) && String.Equals(school.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
+                Campuses = new Collection<SearchAndCompare.Domain.Models.Campus>(
+                    courseSites
                     .Select(school =>
                         new SearchAndCompare.Domain.Models.Campus
                         {
@@ -114,7 +114,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                     Address = address
                 },
 
-                ApplicationsAcceptedFrom = sites.Select(x => x.ApplicationsAcceptedFrom).Where(x => x.HasValue)
+                ApplicationsAcceptedFrom = courseSites.Select(x => x.ApplicationsAcceptedFrom).Where(x => x.HasValue)
                     .OrderBy(x => x.Value)
                     .FirstOrDefault(),
 

--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -43,8 +43,6 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                         Name = subject
                     }
                 }).ToList());
-            var isFurtherEducation = subjects.Any(c =>
-                c.Subject.Name.Equals("Further education", StringComparison.InvariantCultureIgnoreCase));
 
             var provider = new SearchAndCompare.Domain.Models.Provider
             {

--- a/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
+++ b/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
@@ -82,7 +82,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
                     .Select(x => GetCourse(providerCode, x.CourseCode, email, ucasProviderData, orgEnrichmentData)));
             }
 
-            return courses.Where(courseToSave => courseToSave.IsValid(false)).ToList();
+            return courses.Where(courseToSave => courseToSave.IsValid(false) && courseToSave.Campuses.Any()).ToList();
         }
 
         private async Task<bool> SaveImplementation(IList<Course> courses, string providerCode)

--- a/src/ManageCourses.CourseExporterUtil/Publisher.cs
+++ b/src/ManageCourses.CourseExporterUtil/Publisher.cs
@@ -91,7 +91,6 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
             {
                 course.CourseSites = new Collection<CourseSite>(course.CourseSites.Where(x => x.Publish == "Y").ToList());
             }
-            courses.Where(x => x.CourseSites.Any(y => y.Publish =="Y")).ToList();
 
             _logger.Information($" - {courses.Count()} courses");
 

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -73,6 +73,17 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         [NotMapped]
         public bool HasVacancies { get => CourseSites?.Any(s => s.VacStatus == "B" || s.VacStatus == "F" || s.VacStatus == "P") ?? false;}
 
+        [NotMapped]
+        public IEnumerable<CourseSite> PublishableSites
+        {
+            get
+            {
+                return CourseSites?.Where(courseSite =>
+                    string.Equals(courseSite.Status, "r", StringComparison.InvariantCultureIgnoreCase)
+                    && string.Equals(courseSite.Publish, "y", StringComparison.InvariantCultureIgnoreCase))
+                    ?? new List<CourseSite>();
+            }
+        }
 
         private string GetCourseVariantType()
         {

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -160,7 +160,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             res.ContactDetails.Website.Should().Be("http://www.example.com");
             res.ContactDetails.Address.Should().Be("Addr1\nAddr2\nAddr3\nAddr4\nPostcode");
 
-            res.ApplicationsAcceptedFrom.Should().Be(new System.DateTime(2018, 10, 16));
+            res.ApplicationsAcceptedFrom.Should().BeNull();
 
             res.FullTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);
             res.PartTime.Should().Be(SearchAndCompare.Domain.Models.Enums.VacancyStatus.Vacancies);

--- a/tests/ManageCourses.Tests/UnitTesting/Model/CourseTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/Model/CourseTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.Domain.Models;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.UnitTesting.Model
+{
+    [TestFixture]
+    public class CourseTests
+    {
+        [Test]
+        public void PublishableSites_NullSites()
+        {
+            var course = new Course
+            {
+                CourseSites = null,
+            };
+            course.PublishableSites.Should().HaveCount(0);
+        }
+
+        [Test]
+        public void PublishableSites_NoSites()
+        {
+            var course = new Course
+            {
+                CourseSites = new List<CourseSite>(),
+            };
+            course.PublishableSites.Should().HaveCount(0);
+        }
+
+        [Test]
+        // uppercase
+        [TestCase("N", "N", false)]
+        [TestCase("R", "N", false)]
+        [TestCase("S", "N", false)]
+        [TestCase("D", "N", false)]
+        [TestCase("N", "Y", false)]
+        [TestCase("R", "Y", true)]
+        [TestCase("S", "Y", false)]
+        [TestCase("D", "Y", false)]
+        // lowercase
+        [TestCase("n", "n", false)]
+        [TestCase("r", "n", false)]
+        [TestCase("s", "n", false)]
+        [TestCase("d", "n", false)]
+        [TestCase("n", "y", false)]
+        [TestCase("r", "y", true)]
+        [TestCase("s", "y", false)]
+        [TestCase("d", "y", false)]
+        public void PublishableSites_AllVariations(string status, string publish, bool publishable)
+        {
+            var course = new Course
+            {
+                CourseSites = new List<CourseSite>
+                {
+                    new CourseSite
+                    {
+                        Status = status,
+                        Publish = publish,
+                    }
+                },
+            };
+            course.PublishableSites.Should().HaveCount(publishable ? 1 : 0);
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
@@ -55,7 +55,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             };
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))
-                .Returns(new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" });
+                .Returns(BuildCourse(provider));
 
             _dataServiceMock.Setup(x => x.GetCoursesForUser(email, ProviderCode))
                 .Returns(new List<Course>{ new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" } } );
@@ -90,7 +90,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
 
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))
-                .Returns(new Course { CourseCode = CourseCode, Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "History"}}}, Name = "History" });
+                .Returns(BuildCourse(provider));
 
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode + "1"))
                 .Returns(new Course { CourseCode = CourseCode + "1", Provider = provider, ProgramType = "SD", CourseSubjects = new List<CourseSubject> { new CourseSubject { Subject = new Subject { SubjectName = "Geography"}}}, Name = "Geography" });
@@ -120,6 +120,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             result.Should().BeTrue();
             _httpMock.VerifyAll();
         }
+
         [Test]
         public void PublishEnrichedCourseWithEmailDraftTest()
         {
@@ -242,6 +243,26 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             var result = _searchAndCompareService.SaveCourses(providerCode, email).Result;
 
             result.Should().BeFalse();
+        }
+
+        private static Course BuildCourse(Provider provider)
+        {
+            return new Course
+            {
+                CourseCode = CourseCode, Provider = provider, ProgramType = "SD",
+                CourseSubjects = new List<CourseSubject>
+                    {new CourseSubject {Subject = new Subject {SubjectName = "History"}}},
+                Name = "History",
+                CourseSites = new List<CourseSite>
+                {
+                    new CourseSite
+                    {
+                        Status = "R",
+                        Publish = "Y",
+                        Site = new Site(),
+                    }
+                }
+            };
         }
     }
 }


### PR DESCRIPTION
### Context

Publish endpoint(s) are publishing courses even if they have no published & running sites. The mcb command for publishing a whole provider was triggering this, which then was reset by the bulk publisher, except that the bulk publisher circuit breaker tripped when it reduced the course count back down to the correct number.

### Changes proposed in this pull request

This brings the publish controller into line with the bulk publisher.

* Expand filtering in GetValidCourses to eliminate courses without any
  running/published sites (aka campuses). - this is specific to the publish endpoints unlike the original patch

### Guidance to review

You might find it easier to read each commit rather than the whole diff.

:eye: :eye: 

* The first commit is the behaviour fix, and fixup of test data.
* The second commit is a refactor to introduce a common place for the logic on the `Course` model.
* The third/fourth commits remove code that doesn't do anything.