### PR TITLE
Added additional logging options for Windows apps

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -351,7 +351,16 @@
                     "appServiceName": {
                         "value": "[variables('appServiceName')]"
                     },
+                    "applicationLogsFileSystem": {
+                        "value": "Error"
+                    },
                     "httpLoggingEnabled": {
+                        "value": true
+                    },
+                    "requestTracingEnabled": {
+                        "value": true
+                    },
+                    "detailedErrorLoggingEnabled": {
                         "value": true
                     }
                 }


### PR DESCRIPTION
### Context
Added additional logging options for Windows apps missed in previous commit.
Enable App Service Logs for the service. 
### Changes proposed in this pull request
Add a resource deployment to the apps ARM template that references the App Service Log building block.
