### PR TITLE
[1727] 2019 vs 2020 course enrichments followup

### DIFF
--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -146,7 +146,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
             providerCode = providerCode.ToUpperInvariant();
 
             var enrichments = _context.CourseEnrichments.FromSql(@"
-SELECT b.id, b.created_by_user_id, b.created_at, b.provider_code, null as json_data, b.last_published_timestamp_utc, b.status, b.ucas_course_code, b.updated_by_user_id, b.updated_at
+SELECT b.id, b.created_by_user_id, b.created_at, b.provider_code, null as json_data, b.last_published_timestamp_utc, b.status, b.ucas_course_code, b.updated_by_user_id, b.updated_at, b.course_id
 FROM (SELECT provider_code, ucas_course_code, MAX(id) id FROM course_enrichment GROUP BY provider_code, ucas_course_code) top_id
 INNER JOIN course_enrichment b on top_id.id = b.id")
                 .Where(e => e.ProviderCode == providerCode);

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -181,5 +181,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 
             return returnString;
         }
+
+        public ICollection<CourseEnrichment> CourseEnrichments { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/CourseEnrichment.cs
+++ b/src/ManageCourses.Domain/Models/CourseEnrichment.cs
@@ -19,5 +19,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         [Column(TypeName = "jsonb")]
         public string JsonData { get; set; }
         public EnumStatus Status { get; set; }
+
+        public Course Course {get; set;}
     }
 }


### PR DESCRIPTION
### Context

The model has changed on the rails side. This updates the c# that's still in use to match.

* Model change: https://github.com/DFE-Digital/manage-courses-backend/commit/bb7da1076903066bcfd25a29de379fd00a0395ca#diff-1acd2e7e27a227829d5d14a91c863bb6

Resultant model after all three PRs:

![image](https://user-images.githubusercontent.com/19378/61055300-149c3600-a3e9-11e9-99e5-3c93bec554cf.png)


#### Things still in use in this codebase

* Provider enrichment editing https://bat-qa-mcui-as.azurewebsites.net/organisation/t92/details
* Publish provider's courses
* Bulk publisher webjob / commandline tool


### Changes proposed in this pull request

* fix all the things

### Guidance to review

* :pray: :ship: 
