### PR TITLE
1726 2019 vs 2020 provider enrichments followup

### DIFF
--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -259,6 +259,7 @@ namespace GovUk.Education.ManageCourses.Api.Services
         /// <param name="ucasCourseCode">course code of the enrichemnt to be published</param>
         /// <param name="email">email of the user</param>
         /// <returns>true if successful</returns>
+        [Obsolete("This has been reimplemented in Rails.")]
         public bool PublishCourseEnrichment(string providerCode, string ucasCourseCode, string email)
         {
             var returnBool = false;

--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -302,7 +302,8 @@ namespace GovUk.Education.ManageCourses.Api.Services
             ucasCourseCode = ucasCourseCode.ToUpperInvariant();
 
             var enrichmentsQuery = _context.CourseEnrichments
-                .Where(ie => ie.ProviderCode == providerCode && ie.UcasCourseCode == ucasCourseCode);
+                .Where(ce => ce.Course.Provider.ProviderCode == providerCode
+                             && ce.Course.CourseCode == ucasCourseCode);
 
             if (publishableOnly)
             {

--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -153,9 +153,26 @@ namespace GovUk.Education.ManageCourses.Api.Services
             providerCode = providerCode.ToUpperInvariant();
 
             var enrichments = _context.CourseEnrichments.FromSql(@"
-SELECT b.id, b.created_by_user_id, b.created_at, b.provider_code, null as json_data, b.last_published_timestamp_utc, b.status, b.ucas_course_code, b.updated_by_user_id, b.updated_at, b.course_id
-FROM (SELECT provider_code, ucas_course_code, MAX(id) id FROM course_enrichment GROUP BY provider_code, ucas_course_code) top_id
-INNER JOIN course_enrichment b on top_id.id = b.id")
+                    SELECT b.id,
+                           b.created_by_user_id,
+                           b.created_at,
+                           b.provider_code,
+                           NULL AS json_data,
+                           b.last_published_timestamp_utc,
+                           b.status,
+                           b.ucas_course_code,
+                           b.updated_by_user_id,
+                           b.updated_at,
+                           b.course_id
+                    FROM
+                      (SELECT provider_code,
+                              ucas_course_code,
+                              MAX(id) id
+                       FROM course_enrichment
+                       GROUP BY provider_code,
+                                ucas_course_code) top_id
+                    INNER JOIN course_enrichment b ON top_id.id = b.id
+                    ")
                 .Where(e => e.ProviderCode == providerCode);
 
             return enrichments.Select(x => _converter.Convert(x)).ToList();

--- a/src/ManageCourses.Api/Services/EnrichmentService.cs
+++ b/src/ManageCourses.Api/Services/EnrichmentService.cs
@@ -120,13 +120,15 @@ namespace GovUk.Education.ManageCourses.Api.Services
             var userOrg = ValidateUserOrg(email, providerCode);
 
             providerCode = providerCode.ToUpperInvariant();
+            var provider = _context.Providers
+                .Include(p => p.ProviderEnrichments)
+                .Single(p => p.ProviderCode == providerCode);
 
-            var enrichmentDraftRecord = _context.ProviderEnrichments
-                .Where(ie => ie.ProviderCode == providerCode && ie.Status == EnumStatus.Draft)
+            var enrichmentDraftRecord = provider.ProviderEnrichments
+                .Where(ie => ie.Status == EnumStatus.Draft)
                 .OrderByDescending(x => x.Id)
                 .FirstOrDefault();
 
-            var provider = _context.Providers.Single(p => p.ProviderCode == providerCode);
             var publishTimestamp = DateTime.UtcNow;
             provider.LastPublishedAt = publishTimestamp;
             provider.ChangedAt = publishTimestamp; // make sure change shows in incremental fetch api

--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -8,6 +8,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public Provider()
         {
             Courses = new List<Course>();
+            ProviderEnrichments = new List<ProviderEnrichment>();
             ChangedAt = DateTime.UtcNow;
         }
 

--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -59,5 +59,6 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public ICollection<Course> Courses { get; set; }
         public ICollection<Course> AccreditedCourses { get; set; }
         public ICollection<Site> Sites { get; set; }
+        public ICollection<ProviderEnrichment> ProviderEnrichments { get; set; }
     }
 }

--- a/src/ManageCourses.Domain/Models/ProviderEnrichment.cs
+++ b/src/ManageCourses.Domain/Models/ProviderEnrichment.cs
@@ -37,5 +37,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public string JsonData { get; set; }
 
         public EnumStatus Status { get; set; }
+
+        public Provider Provider { get; set; }
     }
 }

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
@@ -25,6 +25,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         private const string ProviderInstCode = "HNY1";
         private const string AccreditingInstCode = "TRILU";
         private const string UcasCourseCode = "TK101";
+        private const string OtherCourseCode = "D0H";
 
         private const string Email = "12345@example.org";
 
@@ -49,7 +50,12 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                         CourseCode = UcasCourseCode,
                         Name = "Conscious control of telekenisis",
                         AccreditingProvider = accreditingInstitution,
-                    }
+                    },
+                    new Course
+                    {
+                        CourseCode = OtherCourseCode,
+                        Name = "Daemons and Gremlins",
+                    },
                 }
             };
             Context.Add(_ucasInstitution);
@@ -179,11 +185,10 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             {
                 AboutCourse = "Some other course",
             };
-            const string otherCourseCode = "D0H";
-            enrichmentService.SaveCourseEnrichment(nextCourseModel, ProviderInstCode.ToLower(), otherCourseCode, Email);
+            enrichmentService.SaveCourseEnrichment(nextCourseModel, ProviderInstCode.ToLower(), OtherCourseCode, Email);
             var twoCourseMetadata = enrichmentService.GetCourseEnrichmentMetadata(ProviderInstCode, Email);
             twoCourseMetadata.Count.Should().Be(2, "we have enriched two courses in this institution");
-            var nextCourseGet = enrichmentService.GetCourseEnrichment(ProviderInstCode.ToLower(), otherCourseCode, Email);
+            var nextCourseGet = enrichmentService.GetCourseEnrichment(ProviderInstCode.ToLower(), OtherCourseCode, Email);
             nextCourseGet.Should().NotBeNull();
             nextCourseGet.EnrichmentModel.Should().NotBeNull();
             nextCourseGet.EnrichmentModel.AboutCourse.Should().BeEquivalentTo(nextCourseModel.AboutCourse);

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceRegressionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceRegressionTests.cs
@@ -131,7 +131,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                 Status = EnumStatus.Draft,
                 JsonData = content,
             };
-            Context.ProviderEnrichments.Add(enrichment);
+            _ucasInstitution.ProviderEnrichments.Add(enrichment);
             Context.SaveChanges();
         }
 

--- a/tests/ManageCourses.Tests/SmokeTests/TestPayloadBuilder.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/TestPayloadBuilder.cs
@@ -1,37 +1,47 @@
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using GovUk.Education.ManageCourses.Domain.Models;
 using GovUk.Education.ManageCourses.UcasCourseImporter;
 using GovUk.Education.ManageCourses.Xls.Domain;
 
 namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 {
     public static class TestPayloadBuilder {
-        public static UcasPayload MakeSimpleUcasPayload() => new UcasPayload {
-
-                Institutions = ListOfOne(new UcasInstitution {
-                    InstFull = "Joe's school @ UCAS",
-                    InstCode = "ABC"
-                }),
-                            
-                Campuses = ListOfOne(new UcasCampus {
-                    InstCode = "ABC",
-                    CampusCode = "", // NOTE: EMPTY STRING
-                    CampusName = "Main campus site"
-                }),
-
-                Courses = ListOfOne(new UcasCourse {
-                    InstCode = "ABC",
-                    CampusCode = "",
-                    CrseCode = "XYZ",
-                    CrseTitle = "Joe's course for Primary teachers"
-                })
+        public static UcasPayload MakeSimpleUcasPayload()
+        {
+            return new UcasPayload
+            {
+                Institutions = new List<UcasInstitution>
+                {
+                    new UcasInstitution
+                    {
+                        InstFull = "Joe's school @ UCAS",
+                        InstCode = "ABC"
+                    },
+                },
+                Campuses = new List<UcasCampus>{
+                    new UcasCampus
+                    {
+                        InstCode = "ABC",
+                        CampusCode = "",
+                        CampusName = "Main campus site"
+                    }
+                },
+                Courses = new List<UcasCourse>{
+                    new UcasCourse
+                    {
+                        InstCode = "ABC",
+                        CampusCode = "",
+                        CrseCode = "XYZ",
+                        CrseTitle = "Joe's course for Primary teachers"
+                    },
+                    new UcasCourse
+                    {
+                        InstCode = "ABC",
+                        CampusCode = "",
+                        CrseCode = "CC101",
+                        CrseTitle = "Chelsea Tractor"
+                    },
+                },
             };
-        
-        
-        private static List<T> ListOfOne<T> (T one) {
-            return new List<T> { one };
         }
     }
 }


### PR DESCRIPTION
### Context

The model has changed on the rails side. This updates the c# that's still in use to match.

### Changes proposed in this pull request

Make everything use the new FK between enrichments and providers/courses.

### Guidance to review

* :pray: :ship: 

Note that the first three commits are from #316 and will disappear when that is merged and this is rebased