### PR TITLE
1728 use provider recruitment cycle

### DIFF
--- a/src/ManageCourses.CourseExporterUtil/Publisher.cs
+++ b/src/ManageCourses.CourseExporterUtil/Publisher.cs
@@ -78,7 +78,7 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
             }
         }
 
-        private List<SearchCourse> ReadAllCourseData(IManageCoursesDbContext context)
+        public List<SearchCourse> ReadAllCourseData(IManageCoursesDbContext context)
         {
             _logger.Information("Retrieving courses");
             var courses = context.Courses.Include(x => x.Provider)

--- a/src/ManageCourses.CourseExporterUtil/Publisher.cs
+++ b/src/ManageCourses.CourseExporterUtil/Publisher.cs
@@ -81,7 +81,9 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
         public List<SearchCourse> ReadAllCourseData(IManageCoursesDbContext context)
         {
             _logger.Information("Retrieving courses");
-            var courses = context.Courses.Include(x => x.Provider)
+            var courses = context.Courses
+                .Where(x => x.Provider.RecruitmentCycle.Year == RecruitmentCycle.CurrentYear)
+                .Include(x => x.Provider)
                 .Include(x => x.CourseSubjects).ThenInclude(x => x.Subject)
                 .Include(x => x.AccreditingProvider)
                 .Include(x => x.CourseSites).ThenInclude(x => x.Site)
@@ -101,7 +103,7 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
             var orgEnrichments = context.ProviderEnrichments
                 .Include(x => x.CreatedByUser)
                 .Include(x => x.UpdatedByUser)
-                .Where(x => x.Status == EnumStatus.Published)
+                .Where(x => x.Status == EnumStatus.Published && x.Provider.RecruitmentCycle.Year == RecruitmentCycle.CurrentYear)
                 .ToLookup(x => x.ProviderCode)
                 .ToDictionary(x => x.Key, x => x.OrderByDescending(y => y.UpdatedAt).First());
             _logger.Information($" - {orgEnrichments.Count()} orgEnrichments");

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -178,6 +178,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
         public DbSet<CourseEnrichment> CourseEnrichments { get; set; }
         public DbSet<Session> Sessions { get; set; }
         public DbSet<PgdeCourse> PgdeCourses { get; set; }
+        public DbSet<RecruitmentCycle> RecruitmentCycles { get; set; }
 
         public List<Course> GetCourse(string providerCode, string courseCode, string email)
         {

--- a/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/ManageCoursesDbContext.cs
@@ -41,7 +41,7 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
                 .WithMany(u => u.OrganisationUsers);
 
             modelBuilder.Entity<Provider>()
-                .HasIndex(ui => ui.ProviderCode)
+                .HasIndex(p => new { p.RecruitmentCycleId, p.ProviderCode })
                 .IsUnique();
             modelBuilder.Entity<Provider>()
                 .HasIndex(p => p.LastPublishedAt);

--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -55,6 +55,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public DateTime ChangedAt { get; set; }
         public string AccreditingProvider { get; set; }
         public bool OptedIn => true;
+        public RecruitmentCycle RecruitmentCycle { get; set; }
 
         public ICollection<OrganisationProvider> OrganisationProviders { get; set; }
         public ICollection<Course> Courses { get; set; }

--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -55,6 +55,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
         public DateTime ChangedAt { get; set; }
         public string AccreditingProvider { get; set; }
         public bool OptedIn => true;
+        public int RecruitmentCycleId { get; set; }
         public RecruitmentCycle RecruitmentCycle { get; set; }
 
         public ICollection<OrganisationProvider> OrganisationProviders { get; set; }

--- a/src/ManageCourses.Domain/Models/RecruitmentCycle.cs
+++ b/src/ManageCourses.Domain/Models/RecruitmentCycle.cs
@@ -4,6 +4,8 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 {
     public class RecruitmentCycle
     {
+        public const string CurrentYear = "2019";
+
         public int Id { get; set; }
         public string Year { get; set; }
 

--- a/src/ManageCourses.Domain/Models/RecruitmentCycle.cs
+++ b/src/ManageCourses.Domain/Models/RecruitmentCycle.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace GovUk.Education.ManageCourses.Domain.Models
+{
+    public class RecruitmentCycle
+    {
+        public int Id { get; set; }
+        public string Year { get; set; }
+
+        public ICollection<Provider> Providers { get; set; }
+    }
+}

--- a/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/UcasDataMigrator.cs
@@ -18,14 +18,17 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
 
         private readonly ILogger _logger;
         private readonly UcasPayload payload;
+        private readonly RecruitmentCycle _recruitmentCycle;
         private readonly IClock _clock;
 
-        public UcasDataMigrator(ManageCoursesDbContext manageCoursesDbContext, ILogger logger, UcasPayload payload, IClock clock = null)
+        public UcasDataMigrator(ManageCoursesDbContext manageCoursesDbContext, ILogger logger, UcasPayload payload,
+            IClock clock = null, RecruitmentCycle recruitmentCycle = null)
         {
             _context = manageCoursesDbContext;
             _logger = logger;
             _clock = clock ?? new Clock();
             this.payload = payload;
+            _recruitmentCycle = recruitmentCycle;
         }
 
         /// <summary>
@@ -211,6 +214,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter
                 Scitt = x.Scitt,
                 SchemeMember = x.SchemeMember,
                 AccreditingProvider = x.AccreditingProvider,
+                RecruitmentCycle = _recruitmentCycle
             };
         }
 

--- a/tests/ManageCourses.Tests/DbIntegration/Controllers/DevOpsControllerTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/Controllers/DevOpsControllerTests.cs
@@ -38,7 +38,11 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.Controllers
         {
             // arrange
             var courses = new List<Course>();
-            var provider = new Provider { ProviderName = "billy goat school" };
+            var provider = new Provider {
+                ProviderName = "billy goat school" ,
+                RecruitmentCycle = new RecruitmentCycle {Year = RecruitmentCycle.CurrentYear}
+            };
+
             for (var i = 0; i < 20; i++)
             {
                 courses.Add(new Course { Name = "course" + i, Provider = provider });

--- a/tests/ManageCourses.Tests/DbIntegration/Controllers/OrganisationsControllerTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/Controllers/OrganisationsControllerTests.cs
@@ -132,6 +132,9 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             int numSubjects = 3;
             User user = new User { FirstName = "fname", LastName = "lname", Email = email };
             Context.Users.Add(user);
+
+            var recruitmentCycle = new RecruitmentCycle {Year = RecruitmentCycle.CurrentYear};
+
             LoadSubjects(numSubjects);
             for (var counter = 1; counter <= numOrgs; counter++)
             {
@@ -147,7 +150,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     Address4 = "add4",
                     Postcode = "AB1 CD2",
                     ProviderCode = providerCode,
-                    ProviderName = "Intitution " + counter
+                    ProviderName = "Intitution " + counter,
+                    RecruitmentCycle = recruitmentCycle
                 };
                 Context.Providers.Add(provider);
                 LoadCourses(provider, numCourses, Context.Subjects);

--- a/tests/ManageCourses.Tests/DbIntegration/CourseExporterUtilTests/CourseExporterUtilTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/CourseExporterUtilTests/CourseExporterUtilTests.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using GovUk.Education.ManageCourses.CourseExporterUtil;
+using GovUk.Education.ManageCourses.Domain.Models;
+using GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.DbIntegration.CourseExporterUtilTests
+{
+    [TestFixture]
+    [Category("Integration")]
+    [Category("Integration_DB")]
+    [Explicit]
+    public class CourseExporterUtilTests : DbIntegrationTestBase
+    {
+        private const string OptedInWithExistingCourseProviderCode = "OptedInWithExistingCourses";
+
+        private static IEnumerable<Provider> SetupProviders
+        {
+            get
+            {
+                return new List<Provider>
+                {
+                    new ProviderBuilder().WithCode(OptedInWithExistingCourseProviderCode).WithOptedIn()
+                };
+            }
+        }
+
+        protected override void Setup()
+        {
+            var providers = SetupProviders;
+            Context.Providers.AddRange(providers);
+            Context.SaveChanges();
+            SetupDbState();
+        }
+
+        [Test]
+        public void ReadAllCourseData_Returns_Courses()
+        {
+            var publisher = new Publisher(Config);
+            var searchCourses = publisher.ReadAllCourseData(Context);
+            searchCourses.Should().HaveCount(1);
+        }
+
+        // lifted from ManageCourses.Tests/DbIntegration/TransitionService_Intervention_Simple_Tests.cs
+        private void SetupDbState()
+        {
+            var optedInWithExistingCourse = Context.Providers
+                .First(x => x.ProviderCode == OptedInWithExistingCourseProviderCode && x.OptedIn);
+
+            var optedInProviderExistingCourse = CourseBuilder
+                .Build(CourseType.RunningPublished, optedInWithExistingCourse)
+                .WithName("Poetry");
+
+            Context.Courses.Add(optedInProviderExistingCourse);
+
+            Context.Save();
+        }
+
+    }
+}

--- a/tests/ManageCourses.Tests/DbIntegration/CourseExporterUtilTests/CourseExporterUtilTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/CourseExporterUtilTests/CourseExporterUtilTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using FluentAssertions;
 using GovUk.Education.ManageCourses.CourseExporterUtil;
@@ -14,49 +14,145 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.CourseExporterUtilTe
     [Explicit]
     public class CourseExporterUtilTests : DbIntegrationTestBase
     {
-        private const string OptedInWithExistingCourseProviderCode = "OptedInWithExistingCourses";
-
-        private static IEnumerable<Provider> SetupProviders
-        {
-            get
-            {
-                return new List<Provider>
-                {
-                    new ProviderBuilder().WithCode(OptedInWithExistingCourseProviderCode).WithOptedIn()
-                };
-            }
-        }
+        private const string ProviderCode = "A19";
+        private const string AccreditingProviderCode = "ACC19";
+        private const string CourseName2019 = "Poetry 2019";
+        private const string TrainWithUs2019 = "Train 2019";
+        private const string AboutAccreditingProvider2019 = "About 2019";
+        private const string TrainWithDisability2019 = "Disability 2019";
 
         protected override void Setup()
         {
-            var providers = SetupProviders;
-            Context.Providers.AddRange(providers);
-            Context.SaveChanges();
-            SetupDbState();
-        }
+            Course course2019 = CourseBuilder
+                .Build(CourseType.RunningPublished,
+                    new ProviderBuilder()
+                        .WithCycle("2019")
+                        .WithCode(ProviderCode))
+                .WithName(CourseName2019)
+                .WithAccreditingProvider(
+                    new ProviderBuilder()
+                        .WithCycle("2019")
+                        .WithCode(AccreditingProviderCode)
+                );
+            Course course2020 = CourseBuilder
+                .Build(CourseType.RunningPublished,
+                    new ProviderBuilder()
+                        .WithCycle("2020")
+                        .WithCode(ProviderCode))
+                .WithName("Operatics 2020")
+                .WithAccreditingProvider(
+                    new ProviderBuilder()
+                        .WithCycle("2020")
+                        .WithCode(AccreditingProviderCode)
+                );
 
-        [Test]
-        public void ReadAllCourseData_Returns_Courses()
-        {
-            var publisher = new Publisher(Config);
-            var searchCourses = publisher.ReadAllCourseData(Context);
-            searchCourses.Should().HaveCount(1);
-        }
+            Context.Courses.Add(course2019);
+            Context.Courses.Add(course2020);
+            var updatedAt = new DateTime(2001,02,03,04,05,06);
+            var jsonData2019 = @"
+            {
+                ""Email"": ""x@example.org"",
+                ""Website"": ""http://example.org"",
+                ""Address1"": ""add1"",
+                ""Address2"": ""add2"",
+                ""Address3"": ""add3"",
+                ""Address4"": ""add4"",
+                ""Postcode"": ""SW1A 1AA"",
+                ""Telephone"": ""0123321"",
+                ""RegionCode"": 5,
+                ""TrainWithUs"": """+ TrainWithUs2019 + @""",
+                ""TrainWithDisability"": """+ TrainWithDisability2019 + @""",
+                ""AccreditingProviderEnrichments"": [
+                {
+                    ""Description"": """ + AboutAccreditingProvider2019 + @""",
+                    ""UcasProviderCode"": """ + AccreditingProviderCode + @"""
+                }
+                ]
+            }";
 
-        // lifted from ManageCourses.Tests/DbIntegration/TransitionService_Intervention_Simple_Tests.cs
-        private void SetupDbState()
-        {
-            var optedInWithExistingCourse = Context.Providers
-                .First(x => x.ProviderCode == OptedInWithExistingCourseProviderCode && x.OptedIn);
+            var jsonData2020 = @"
+            {
+                ""Email"": ""2020"",
+                ""Website"": ""2020"",
+                ""Address1"": ""2020"",
+                ""Address2"": ""2020"",
+                ""Address3"": ""2020"",
+                ""Address4"": ""2020"",
+                ""Postcode"": ""2020"",
+                ""Telephone"": ""2020"",
+                ""RegionCode"": 5,
+                ""TrainWithUs"": ""2020"",
+                ""TrainWithDisability"": ""2020"",
+                ""AccreditingProviderEnrichments"": [
+                {
+                    ""Description"": ""2020"",
+                    ""UcasProviderCode"": """ + AccreditingProviderCode + @"""
+                }
+                ]
+            }";
 
-            var optedInProviderExistingCourse = CourseBuilder
-                .Build(CourseType.RunningPublished, optedInWithExistingCourse)
-                .WithName("Poetry");
+            course2019.Provider.ProviderEnrichments.Add(
+                new ProviderEnrichment
+                {
+                    ProviderCode = ProviderCode,
+                    UpdatedAt = updatedAt,
+                    JsonData = jsonData2019,
+                    Status = EnumStatus.Published,
+                    CreatedByUser = new User(),
+                    UpdatedByUser = new User()
+            });
 
-            Context.Courses.Add(optedInProviderExistingCourse);
+            course2020.Provider.ProviderEnrichments.Add(
+                new ProviderEnrichment
+                {
+                    ProviderCode = ProviderCode,
+                    UpdatedAt = updatedAt.AddYears(1),
+                    JsonData = jsonData2020,
+                    Status = EnumStatus.Published,
+                    CreatedByUser = new User(),
+                    UpdatedByUser = new User()
+            });
 
             Context.Save();
         }
 
+        [Test]
+        public void ReadAllCourseData_Returns_2019_Course()
+        {
+            var publisher = new Publisher(Config);
+
+            var searchCourses = publisher.ReadAllCourseData(Context);
+
+            searchCourses.Should().HaveCount(1,
+                $"provider {ProviderCode} has one copy in the 2019 cycle and one in 2020");
+            var course = searchCourses.Single();
+            course.Provider.ProviderCode.Should().Be(ProviderCode);
+            course.Name.Should().Be(CourseName2019);
+        }
+
+        [Test]
+        public void ReadAllCourseData_Returns_2019_ProviderEnrichment()
+        {
+            var publisher = new Publisher(Config);
+
+            var searchCourses = publisher.ReadAllCourseData(Context);
+
+            var course = searchCourses.Single();
+
+            course.AccreditingProvider.Should().NotBeNull();
+
+            course.AccreditingProvider.ProviderCode.Should().Be(AccreditingProviderCode);
+
+            course.DescriptionSections.Select(x => x.Text).All(x => string.IsNullOrWhiteSpace(x)).Should().BeFalse("The provider enrichment should be mapped.");
+
+            var aboutTrainingProviderAccreditingSection = course.DescriptionSections.Single(cd => cd.Name == "about this training provider accrediting");
+            aboutTrainingProviderAccreditingSection.Text.Should().Be(AboutAccreditingProvider2019);
+
+            var aboutTrainingProviderSection = course.DescriptionSections.Single(cd => cd.Name == "about this training provider");
+            aboutTrainingProviderSection.Text.Should().Be(TrainWithUs2019);
+
+            var trainingDisabilitySection = course.DescriptionSections.Single(cd => cd.Name == "training with disabilities");
+            trainingDisabilitySection.Text.Should().Be(TrainWithDisability2019);
+        }
     }
 }

--- a/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DataServiceTests.cs
@@ -117,7 +117,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     Address4 = "add4",
                     Postcode = "AB1 CD2",
                     ProviderCode = providerCode,
-                    ProviderName = "Provider " + counter
+                    ProviderName = "Provider " + counter,
+                    RecruitmentCycle = new RecruitmentCycle{ Year = RecruitmentCycle.CurrentYear}
                 };
                 Context.Providers.Add(provider);
                 LoadCourses(provider, numCourses, Context.Subjects, reverseCourseOrder);

--- a/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using GovUk.Education.ManageCourses.Api.Services;
 using GovUk.Education.ManageCourses.Domain;
 using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
+using GovUk.Education.ManageCourses.Domain.Models;
 using GovUk.Education.ManageCourses.Tests.TestUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -21,6 +24,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         protected DateTime MockTime;
         protected Mock<IClock> MockClock;
         protected TestConfigReader TestConfig;
+
+        private protected RecruitmentCycle CurrentRecruitmentCycle => Context.RecruitmentCycles.Single(rc => rc.Year == RecruitmentCycle.CurrentYear);
 
         protected virtual bool EnableRetryOnFailure => true;
 
@@ -65,6 +70,14 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
 
             // reset clock
             MockTime = new DateTime(1977, 1, 2, 3, 4, 5, 7);
+
+            Context.RecruitmentCycles.AddRange(
+                new List<RecruitmentCycle>
+                {
+                    new RecruitmentCycle {Year = RecruitmentCycle.CurrentYear},
+                    new RecruitmentCycle {Year = "2020"},
+                });
+            Context.SaveChanges();
 
             // allow derived tests to do their own setup
             Setup();

--- a/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DbIntegrationTestBase.cs
@@ -25,7 +25,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         protected Mock<IClock> MockClock;
         protected TestConfigReader TestConfig;
 
-        private protected RecruitmentCycle CurrentRecruitmentCycle => Context.RecruitmentCycles.Single(rc => rc.Year == RecruitmentCycle.CurrentYear);
+        protected RecruitmentCycle CurrentRecruitmentCycle => Context.RecruitmentCycles.Single(rc => rc.Year == RecruitmentCycle.CurrentYear);
 
         protected virtual bool EnableRetryOnFailure => true;
 

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
@@ -35,6 +35,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             {
                 ProviderName = "Trilby University", // Universities can accredit courses provided by schools / SCITTs
                 ProviderCode = AccreditingInstCode,
+                RecruitmentCycle = CurrentRecruitmentCycle,
             };
             Context.Add(accreditingInstitution);
 
@@ -56,7 +57,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                         CourseCode = OtherCourseCode,
                         Name = "Daemons and Gremlins",
                     },
-                }
+                },
+                RecruitmentCycle = CurrentRecruitmentCycle,
             };
             Context.Add(_ucasInstitution);
 
@@ -195,21 +197,9 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         }
 
         [Test]
-        [TestCase("eqweqw", "qweqweq")]
-        public void Test_SaveCourseEnrichment_should_return_invalid_operation_exception(string instCode, string email)
-        {
-            const string aboutCourseText = "About Course Text";
-
-            var enrichmentService = new EnrichmentService(Context);
-            var model = new CourseEnrichmentModel
-            {
-                AboutCourse = aboutCourseText,
-            };
-            Assert.Throws<InvalidOperationException>(() => enrichmentService.SaveCourseEnrichment(model, instCode, UcasCourseCode, email));
-        }
-        [Test]
         [TestCase("", "")]
         [TestCase(null, null)]
+        [TestCase("eqweqw", "qweqweq")]
         public void Test_SaveCourseEnrichment_should__argument_exception(string instCode, string email)
         {
             const string aboutCourseText = "About Course Text";
@@ -228,19 +218,13 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         {
             var enrichmentService = new EnrichmentService(Context);
 
-            Assert.Throws<InvalidOperationException>(() => enrichmentService.GetCourseEnrichment(instCode, UcasCourseCode, email));
+            Assert.Throws<ArgumentException>(() => enrichmentService.GetCourseEnrichment(instCode, UcasCourseCode, email));
         }
-        [Test]
-        [TestCase("eqweqw", "qweqweq")]
-        public void Test_PublishCourseEnrichment_should_return_invalid_operation_exception(string instCode, string email)
-        {
-            var enrichmentService = new EnrichmentService(Context);
 
-            Assert.Throws<InvalidOperationException>(() => enrichmentService.PublishCourseEnrichment(instCode, UcasCourseCode, email));
-        }
         [Test]
         [TestCase("", "")]
         [TestCase(null, null)]
+        [TestCase("eqweqw", "qweqweq")]
         public void Test_PublishCourseEnrichment_should_argument_exception(string instCode, string email)
         {
             var enrichmentService = new EnrichmentService(Context);

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
@@ -33,6 +33,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             {
                 ProviderName = "Trilby University", // Universities can accredit courses provided by schools / SCITTs
                 ProviderCode = AccreditingInstCode,
+                RecruitmentCycle = CurrentRecruitmentCycle,
             };
             Context.Add(accreditingInstitution);
 
@@ -51,7 +52,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                         AccreditingProvider = accreditingInstitution,
                     }
                 },
-                RegionCode = RegionCode
+                RegionCode = RegionCode,
+                RecruitmentCycle = CurrentRecruitmentCycle,
             };
             Context.Add(_ucasInstitution);
 
@@ -202,37 +204,11 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             publishedCount.Should().Be(1);
             draftCount.Should().Be(1);
         }
-        [Test]
-        [TestCase("eqweqw", "qweqweq")]
-        public void Test_SaveInstitutionEnrichment_should_return_invalid_operation_exception(string instCode, string email)
-        {
-            const string trainWithDisabilityText = "TrainWithDisabilily Text";
-            const string trainWithUsText = "TrainWithUs Text";
-            const string instDesc = "school1 description enrichement";
 
-            var enrichmentService = new EnrichmentService(Context);
-            var model = new UcasProviderEnrichmentPostModel
-            {
-                EnrichmentModel = new ProviderEnrichmentModel
-                {
-                    TrainWithDisability = trainWithDisabilityText,
-                    TrainWithUs = trainWithUsText,
-                    AccreditingProviderEnrichments = new List<AccreditingProviderEnrichment>
-                    {
-                        new AccreditingProviderEnrichment
-                        {
-                            UcasProviderCode = AccreditingInstCode,
-                            Description = instDesc,
-                        }
-                    }
-                }
-            };
-
-            Assert.Throws<InvalidOperationException>(() => enrichmentService.SaveProviderEnrichment(model, instCode, email));
-        }
         [Test]
         [TestCase("", "")]
         [TestCase(null, null)]
+        [TestCase("eqweqw", "qweqweq")]
         public void Test_SaveInstitutionEnrichment_should__argument_exception(string instCode, string email)
         {
             const string trainWithDisabilityText = "TrainWithDisabilily Text";
@@ -259,30 +235,26 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
 
             Assert.Throws<ArgumentException>(() => enrichmentService.SaveProviderEnrichment(model, instCode, email));
         }
+
         [Test]
         [TestCase("eqweqw", "qweqweq")]
         public void Test_GetInstitutionEnrichment_should_error(string instCode, string email)
         {
             var enrichmentService = new EnrichmentService(Context);
 
-            Assert.Throws<InvalidOperationException>(() => enrichmentService.GetProviderEnrichment(instCode, email));
+            Assert.Throws<ArgumentException>(() => enrichmentService.GetProviderEnrichment(instCode, email));
         }
-        [Test]
-        [TestCase("eqweqw", "qweqweq")]
-        public void Test_PublishInstitutionEnrichment_should_return_invalid_operation_exception(string instCode, string email)
-        {
-            var enrichmentService = new EnrichmentService(Context);
 
-            Assert.Throws<InvalidOperationException>(() => enrichmentService.PublishProviderEnrichment(instCode, email));
-        }
         [Test]
         [TestCase("", "")]
         [TestCase(null, null)]
+        [TestCase("eqweqw", "qweqweq")]
         public void Test_PublishInstitutionEnrichment_should_argument_exception(string instCode, string email)
         {
             var enrichmentService = new EnrichmentService(Context);
             Assert.Throws<ArgumentException>(() => enrichmentService.PublishProviderEnrichment(instCode, email));
         }
+
         [Test]
         public void Test_PublishInstitutionEnrichment_should_return_false()
         {

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceRegressionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceRegressionTests.cs
@@ -42,6 +42,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
             {
                 ProviderName = "Trilby University", // Universities can accredit courses provided by schools / SCITTs
                 ProviderCode = AccreditingInstCode,
+                RecruitmentCycle = CurrentRecruitmentCycle,
             };
             Context.Add(accreditingInstitution);
 
@@ -59,7 +60,8 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                         Name = "Conscious control of telekenisis",
                         AccreditingProvider = accreditingInstitution,
                     }
-                }
+                },
+                RecruitmentCycle = CurrentRecruitmentCycle,
             };
             Context.Add(_ucasInstitution);
 

--- a/tests/ManageCourses.Tests/DbIntegration/TransitionServiceTestsBase.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/TransitionServiceTestsBase.cs
@@ -32,11 +32,19 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
         {
             Service = new TransitionService(Context);
 
+
             var providers = SetupProviders
                 .Select(x => new OrganisationProvider
                     {
                         Provider = x,
                     }).ToList();
+
+            var currentRecruitmentCycle = new RecruitmentCycle{ Year = RecruitmentCycle.CurrentYear};
+
+            foreach (var item in providers)
+            {
+                item.Provider.RecruitmentCycle = currentRecruitmentCycle;
+            }
 
             var user = new User
             {

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/CourseBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/CourseBuilder.cs
@@ -13,6 +13,16 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
         {
             _course = new Course();
             _course.CourseSites = new List<CourseSite>();
+            _course.CourseSubjects = new List<CourseSubject>
+            {
+                new CourseSubject
+                {
+                    Subject = new Subject
+                    {
+                        SubjectName = "Primary",
+                    },
+                }
+            };
         }
 
         public CourseBuilder WithCode(string courseCode)
@@ -59,7 +69,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
         public CourseBuilder AddCourseSites(params CourseType[] courseTypes)
         {
             var result = new List<CourseSite>(_course.CourseSites) {};
-            result.AddRange(courseTypes.Select(c => (CourseSite)CourseSiteBuilder.Build(c)));
+            result.AddRange(courseTypes.Select(c => (CourseSite)CourseSiteBuilder.Build(c, _course)));
             _course.CourseSites = result;
             return this;
         }

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/CourseSiteBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/CourseSiteBuilder.cs
@@ -1,7 +1,6 @@
-using System.Collections.Generic;
-using System;
 using System.Linq;
 using GovUk.Education.ManageCourses.Domain.Models;
+using GovUk.Education.Manages.Tests.ImporterTests.DbBuilders;
 
 namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
 {
@@ -11,11 +10,13 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
 
         public CourseSiteBuilder()
         {
-            _courseSite = new CourseSite();
-            _courseSite.Publish = "N";
+            _courseSite = new CourseSite
+            {
+                Publish = "N",
+            };
         }
 
-        public static CourseSiteBuilder Build(CourseType courseType)
+        public static CourseSiteBuilder Build(CourseType courseType, Course course = null)
         {
             var result = new CourseSiteBuilder();
 
@@ -62,6 +63,9 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
                     break;
                 }
             }
+
+            result._courseSite.Site = course?.Provider?.Sites?.FirstOrDefault();
+
             return result;
         }
 

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/ProviderBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/ProviderBuilder.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using GovUk.Education.ManageCourses.Domain.Models;
+using GovUk.Education.Manages.Tests.ImporterTests.DbBuilders;
 
 namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
 {
@@ -9,7 +10,13 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
 
         public ProviderBuilder()
         {
-            _provider = new Provider();
+            _provider = new Provider
+            {
+                Sites = new List<Site>
+                {
+                    new SiteBuilder(),
+                }
+            };
         }
 
         public ProviderBuilder WithCode(string providerCode)

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/ProviderBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/ProviderBuilder.cs
@@ -57,5 +57,21 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
             _provider.Courses.Add(course);
             return this;
         }
+
+        public ProviderBuilder WithCycle(string year)
+        {
+            _provider.RecruitmentCycle = new RecruitmentCycle
+            {
+                Year = year,
+            };
+            return this;
+        }
+
+        public ProviderBuilder WithCycle(RecruitmentCycle recruitmentCycle)
+        {
+            _provider.RecruitmentCycle = recruitmentCycle;
+
+            return this;
+        }
     }
 }

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/SiteBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/SiteBuilder.cs
@@ -1,0 +1,25 @@
+using GovUk.Education.ManageCourses.Domain.Models;
+
+namespace GovUk.Education.Manages.Tests.ImporterTests.DbBuilders
+{
+    internal class SiteBuilder
+    {
+        private readonly Site _Site;
+
+        public SiteBuilder()
+        {
+            _Site = new Site();
+        }
+
+        public static SiteBuilder Build()
+        {
+            var result = new SiteBuilder();
+            return result;
+        }
+
+        public static implicit operator Site(SiteBuilder builder)
+        {
+            return builder._Site;
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorAllVariationTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorAllVariationTests.cs
@@ -16,6 +16,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
     [Category("Integration")]
     [Category("Integration_DB")]
     [Explicit]
+    [Ignore("Ucas importer is no longer in use.")]
     public class UcasDataMigratorAllVariationTests: DbIntegrationTestBase
     {
         /// <summary>

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorOptInTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorOptInTests.cs
@@ -16,6 +16,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
     [Category("Integration")]
     [Category("Integration_DB")]
     [Explicit]
+    [Ignore("Ucas importer is no longer in use.")]
     public class UcasDataMigratorOptInTests : DbIntegrationTestBase
     {
         /// <summary>

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorTests.cs
@@ -18,6 +18,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
     [Category("Integration")]
     [Category("Integration_DB")]
     [Explicit]
+    [Ignore("Ucas importer is no longer in use.")]
     public class UcasDataMigratorTests : DbIntegrationTestBase
     {
         private const string InstPostCode1 = "AB12CD";

--- a/tests/ManageCourses.Tests/ManageCourses.Tests.csproj
+++ b/tests/ManageCourses.Tests/ManageCourses.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ManageCourses.Api\ManageCourses.Api.csproj" />
+    <ProjectReference Include="..\..\src\ManageCourses.CourseExporterUtil\ManageCourses.CourseExporterUtil.csproj" />
     <ProjectReference Include="..\..\src\ManageCourses.Domain\ManageCourses.Domain.csproj" />
     <ProjectReference Include="..\..\src\ManageCourses.ApiClient\ManageCourses.ApiClient.csproj" />
     <ProjectReference Include="..\..\src\ManageCourses.UcasCourseImporter\importer\UcasCourseImporter.csproj" />

--- a/tests/ManageCourses.Tests/SmokeTests/ReferenceDataBuilder.cs
+++ b/tests/ManageCourses.Tests/SmokeTests/ReferenceDataBuilder.cs
@@ -7,7 +7,7 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
 {
     public static class ReferenceDataExtensions
     {
-        public static void AddTestReferenceData(this ManageCoursesDbContext context, string username)
+        public static void AddTestReferenceData(this ManageCoursesDbContext context, string username, RecruitmentCycle recruitmentCycle)
         {
             User user = new User
             {
@@ -28,20 +28,21 @@ namespace GovUk.Education.ManageCourses.Tests.SmokeTests
             Provider provider = new Provider
             {
                 ProviderName = "Joe's school @ UCAS",
-                ProviderCode = "ABC"
+                ProviderCode = "ABC",
+                RecruitmentCycle = recruitmentCycle,
             };
             context.Providers.Add(provider);
-            
+
             context.OrganisationUsers.Add(new OrganisationUser {
                     User = user,
                     Organisation = organisation
                 });
-            
+
             context.OrganisationProviders.Add(new OrganisationProvider {
                     Provider = provider,
                     Organisation = organisation
                 });
-            
+
         }
     }
 }


### PR DESCRIPTION
### Context

The model has changed on the rails side. This updates the c# that's still in use to match.

### Changes proposed in this pull request

Make everything use the new FK between `provider` and `recruitment_cycle`

### Guidance to review

* :pray: :ship: 

Note that this builds on #317 and those commits will disappear when that is merged and this is rebased