### PR TITLE
[1759] Use course.accrediting_provider_code instead of fk

### DIFF
--- a/src/ManageCourses.Api/Controllers/PublishController.cs
+++ b/src/ManageCourses.Api/Controllers/PublishController.cs
@@ -7,6 +7,7 @@ using GovUk.Education.ManageCourses.Api.Services;
 using GovUk.Education.ManageCourses.Api.Services.Publish;
 using Microsoft.AspNetCore.Mvc;
 using GovUk.Education.ManageCourses.Api.ActionFilters;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
 
 namespace GovUk.Education.ManageCourses.Api.Controllers
 {
@@ -15,13 +16,19 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
     {
         private readonly IDataService _dataService;
         private readonly ISearchAndCompareService _searchAndCompareService;
+        private readonly IManageCoursesDbContext _context;
         private readonly IEnrichmentService _enrichmentservice;
         private readonly ITransitionService _transitionService;
 
-        public PublishController(IDataService dataService, IEnrichmentService enrichmentservice, ITransitionService transitionService,ISearchAndCompareService searchAndCompareService)
+        public PublishController(IDataService dataService,
+            IEnrichmentService enrichmentservice,
+            ITransitionService transitionService,
+            ISearchAndCompareService searchAndCompareService,
+            IManageCoursesDbContext context)
         {
             _dataService = dataService;
             _searchAndCompareService = searchAndCompareService;
+            _context = context;
             _enrichmentservice = enrichmentservice;
             _transitionService = transitionService;
         }
@@ -126,7 +133,7 @@ namespace GovUk.Education.ManageCourses.Api.Controllers
                 return BadRequest();
             }
 
-            var courseMapper = new CourseMapper();
+            var courseMapper = new CourseMapper(_context.GetProviderName);
 
             var providerData = _dataService.GetProviderForUser(name, providerCode);
             var orgEnrichmentData = _enrichmentservice.GetProviderEnrichment(providerCode, name);

--- a/src/ManageCourses.Api/Mapping/CourseMapper.cs
+++ b/src/ManageCourses.Api/Mapping/CourseMapper.cs
@@ -12,6 +12,13 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
 {
     public class CourseMapper : ICourseMapper
     {
+        private Func<string, string> GetProviderName { get; }
+
+        public CourseMapper(Func<string, string> getProviderName)
+        {
+            GetProviderName = getProviderName;
+        }
+
         private readonly SubjectMapper subjectMapper = new SubjectMapper();
 
         public SearchAndCompare.Domain.Models.Course MapToSearchAndCompareCourse(Domain.Models.Provider ucasProviderData, Domain.Models.Course ucasCourseData, ProviderEnrichmentModel providerEnrichmentModel, CourseEnrichmentModel courseEnrichmentModel)
@@ -50,12 +57,16 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
                 ProviderCode = ucasProviderData.ProviderCode
             };
 
-            var accreditingProvider = ucasCourseData.AccreditingProvider == null ? null :
-                new SearchAndCompare.Domain.Models.Provider
+            GovUk.Education.SearchAndCompare.Domain.Models.Provider accreditingProvider = null;
+            if (!string.IsNullOrWhiteSpace(ucasCourseData.AccreditingProviderCode) && GetProviderName != null)
+            {
+                accreditingProvider = new SearchAndCompare.Domain.Models.Provider
                 {
-                    Name = ucasCourseData.AccreditingProvider.ProviderName,
-                    ProviderCode = ucasCourseData.AccreditingProvider.ProviderCode
+                    Name = GetProviderName(ucasCourseData.AccreditingProviderCode),
+                    ProviderCode = ucasCourseData.AccreditingProviderCode,
                 };
+
+            }
 
             var routeName = ucasCourseData.Route;
             var isSalaried = string.Equals(ucasCourseData?.ProgramType, "ss", StringComparison.InvariantCultureIgnoreCase)
@@ -189,7 +200,7 @@ namespace GovUk.Education.ManageCourses.Api.Mapping
             mappedCourse.DescriptionSections.Add(new CourseDescriptionSection
             {
                 Name = "about this training provider accrediting",//CourseDetailsSections.AboutTheAccreditingProvider,
-                Text = GetAccreditingProviderEnrichment(ucasCourseData?.AccreditingProvider?.ProviderCode, providerEnrichmentModel)
+                Text = GetAccreditingProviderEnrichment(ucasCourseData?.AccreditingProviderCode, providerEnrichmentModel)
             });
 
             mappedCourse.DescriptionSections.Add(new CourseDescriptionSection

--- a/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
+++ b/src/ManageCourses.Api/Services/Publish/SearchAndCompareService.cs
@@ -52,6 +52,7 @@ namespace GovUk.Education.ManageCourses.Api.Services.Publish
         /// <param name="courseCode">code for the course (if a single course is to be published)</param>
         /// <param name="email">email of the user</param>
         /// <returns></returns>
+        [Obsolete("This has been reimplemented in Rails.")]
         public async Task<bool> SaveCourse(string providerCode, string courseCode, string email)
         {
             if (string.IsNullOrWhiteSpace(providerCode) || string.IsNullOrWhiteSpace(courseCode) || string.IsNullOrWhiteSpace(email))

--- a/src/ManageCourses.Api/Startup.cs
+++ b/src/ManageCourses.Api/Startup.cs
@@ -91,7 +91,12 @@ namespace GovUk.Education.ManageCourses.Api
                 });
 
             services.AddScoped<ISearchAndCompareService, SearchAndCompareService>();
-            services.AddScoped<ICourseMapper, CourseMapper>();
+            services.AddScoped<ICourseMapper, CourseMapper>(provider =>
+            {
+
+                var dbContext = provider.GetService<IManageCoursesDbContext>();
+                return new CourseMapper(dbContext.GetProviderName);
+            });
             services.AddScoped<IDataService, DataService>();
             services.AddScoped<IUserService, UserService>();
             services.AddScoped<IInviteService, InviteService>();

--- a/src/ManageCourses.CourseExporterUtil/Publisher.cs
+++ b/src/ManageCourses.CourseExporterUtil/Publisher.cs
@@ -85,7 +85,6 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
                 .Where(x => x.Provider.RecruitmentCycle.Year == RecruitmentCycle.CurrentYear)
                 .Include(x => x.Provider)
                 .Include(x => x.CourseSubjects).ThenInclude(x => x.Subject)
-                .Include(x => x.AccreditingProvider)
                 .Include(x => x.CourseSites).ThenInclude(x => x.Site)
                 .Include(x => x.CourseEnrichments).ThenInclude(x => x.CreatedByUser)
                 .Include(x => x.CourseEnrichments).ThenInclude(x => x.UpdatedByUser)
@@ -111,7 +110,9 @@ namespace GovUk.Education.ManageCourses.CourseExporterUtil
             var pgdeCourses = context.PgdeCourses.ToList();
             _logger.Information($" - {pgdeCourses.Count()} pgdeCourses");
 
-            var courseMapper = new CourseMapper();
+
+            var courseMapper = new CourseMapper(context.GetProviderName);
+
             var converter = new EnrichmentConverter();
 
             var mappedCourses = new List<SearchAndCompare.Domain.Models.Course>();

--- a/src/ManageCourses.Domain/DatabaseAccess/IManageCoursesDbContext.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/IManageCoursesDbContext.cs
@@ -34,5 +34,6 @@ namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
 
         IQueryable<User> GetUsers(string email);
         void Save();
+        string GetProviderName(string providerCode);
     }
 }

--- a/src/ManageCourses.Domain/DatabaseAccess/NotFoundException.cs
+++ b/src/ManageCourses.Domain/DatabaseAccess/NotFoundException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace GovUk.Education.ManageCourses.Domain.DatabaseAccess
+{
+    /// <summary>
+    /// Thrown when couldn't find requested entity in database
+    /// </summary>
+    public class NotFoundException : Exception
+    {
+        public NotFoundException(string message)
+            : base(message) { }
+    }
+}

--- a/src/ManageCourses.Domain/Models/Course.cs
+++ b/src/ManageCourses.Domain/Models/Course.cs
@@ -21,8 +21,7 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 
         public int ProviderId { get; set; }
         public Provider Provider {get; set;}
-        public int? AccreditingProviderId { get; set; }
-        public Provider AccreditingProvider {get; set;}
+        public string AccreditingProviderCode {get; set;}
 
         public string CourseCode { get; set; }
         public string ProgramType { get; set; }

--- a/src/ManageCourses.Domain/Models/Provider.cs
+++ b/src/ManageCourses.Domain/Models/Provider.cs
@@ -60,7 +60,6 @@ namespace GovUk.Education.ManageCourses.Domain.Models
 
         public ICollection<OrganisationProvider> OrganisationProviders { get; set; }
         public ICollection<Course> Courses { get; set; }
-        public ICollection<Course> AccreditedCourses { get; set; }
         public ICollection<Site> Sites { get; set; }
         public ICollection<ProviderEnrichment> ProviderEnrichments { get; set; }
     }

--- a/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
+++ b/src/ManageCourses.UcasCourseImporter/importer/Mapping/CourseLoader.cs
@@ -84,7 +84,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Mapping
 
                 if (!string.IsNullOrWhiteSpace(organisationCourseRecord.AccreditingProvider))
                 {
-                    returnCourse.AccreditingProvider = _providerCache[organisationCourseRecord.AccreditingProvider];
+                    returnCourse.AccreditingProviderCode = _providerCache[organisationCourseRecord.AccreditingProvider].ProviderCode;
                 }
 
                 if (!string.IsNullOrWhiteSpace(organisationCourseRecord.InstCode))

--- a/tests/ManageCourses.Tests/DbIntegration/CourseExporterUtilTests/CourseExporterUtilTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/CourseExporterUtilTests/CourseExporterUtilTests.cs
@@ -23,28 +23,23 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration.CourseExporterUtilTe
 
         protected override void Setup()
         {
+            Context.Providers.Add(new ProviderBuilder()
+                .WithCycle("2019")
+                .WithCode(AccreditingProviderCode));
             Course course2019 = CourseBuilder
                 .Build(CourseType.RunningPublished,
                     new ProviderBuilder()
                         .WithCycle("2019")
                         .WithCode(ProviderCode))
                 .WithName(CourseName2019)
-                .WithAccreditingProvider(
-                    new ProviderBuilder()
-                        .WithCycle("2019")
-                        .WithCode(AccreditingProviderCode)
-                );
+                .WithAccreditingProviderCode(AccreditingProviderCode);
             Course course2020 = CourseBuilder
                 .Build(CourseType.RunningPublished,
                     new ProviderBuilder()
                         .WithCycle("2020")
                         .WithCode(ProviderCode))
                 .WithName("Operatics 2020")
-                .WithAccreditingProvider(
-                    new ProviderBuilder()
-                        .WithCycle("2020")
-                        .WithCode(AccreditingProviderCode)
-                );
+                .WithAccreditingProviderCode(AccreditingProviderCode);
 
             Context.Courses.Add(course2019);
             Context.Courses.Add(course2020);

--- a/tests/ManageCourses.Tests/DbIntegration/DbContextTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/DbContextTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using GovUk.Education.ManageCourses.Domain.DatabaseAccess;
+using GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders;
+using NUnit.Framework;
+
+namespace GovUk.Education.ManageCourses.Tests.DbIntegration
+{
+    [TestFixture]
+    public class DbContextTests : DbIntegrationTestBase
+    {
+        private const string ProviderCode = "AB1";
+        private const string ProviderName = "Aberdeen University";
+
+        protected override void Setup()
+        {
+            Context.Providers.Add(new ProviderBuilder()
+                .WithCode(ProviderCode)
+                .WithName(ProviderName)
+                .WithCycle("2019"));
+            Context.Save();
+        }
+
+        [Test]
+        public void TestGetProviderName()
+        {
+            Context.GetProviderName(ProviderCode).Should().Be(ProviderName);
+        }
+
+        [Test]
+        public void TestGetProviderName_ReturnsNull_Empty()
+        {
+            Context.GetProviderName("").Should().BeNull("Code was an empty string");
+            Context.GetProviderName("  ").Should().BeNull("Code was only whitespace");
+        }
+
+        [Test]
+        public void TestGetProviderName_ReturnsNull_ForNullCode()
+        {
+            Context.GetProviderName(null).Should().BeNull();
+        }
+
+        [Test]
+        public void TestGetProviderName_Throws_ForUnknownCode()
+        {
+            Assert.Throws<NotFoundException>(() =>
+            {
+                Context.GetProviderName("X0X").Should().BeNull();
+            });
+        }
+    }
+}

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceCourseTests.cs
@@ -50,7 +50,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     {
                         CourseCode = UcasCourseCode,
                         Name = "Conscious control of telekenisis",
-                        AccreditingProvider = accreditingInstitution,
+                        AccreditingProviderCode = accreditingInstitution.ProviderCode,
                     },
                     new Course
                     {

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceInstitutionTests.cs
@@ -49,7 +49,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     {
                         CourseCode = crseCode,
                         Name = "Conscious control of telekenisis",
-                        AccreditingProvider = accreditingInstitution,
+                        AccreditingProviderCode = accreditingInstitution.ProviderCode,
                     }
                 },
                 RegionCode = RegionCode,

--- a/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceRegressionTests.cs
+++ b/tests/ManageCourses.Tests/DbIntegration/EnrichmentServiceRegressionTests.cs
@@ -58,7 +58,7 @@ namespace GovUk.Education.ManageCourses.Tests.DbIntegration
                     {
                         CourseCode = crseCode,
                         Name = "Conscious control of telekenisis",
-                        AccreditingProvider = accreditingInstitution,
+                        AccreditingProviderCode = accreditingInstitution.ProviderCode,
                     }
                 },
                 RecruitmentCycle = CurrentRecruitmentCycle,

--- a/tests/ManageCourses.Tests/ImporterTests/DbBuilders/CourseBuilder.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/DbBuilders/CourseBuilder.cs
@@ -42,9 +42,9 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests.DbBuilders
             return builder._course;
         }
 
-        public CourseBuilder WithAccreditingProvider(Provider accreditingProvider)
+        public CourseBuilder WithAccreditingProviderCode(string accreditingProviderCode)
         {
-            _course.AccreditingProvider = accreditingProvider;
+            _course.AccreditingProviderCode = accreditingProviderCode;
             return this;
         }
 

--- a/tests/ManageCourses.Tests/ImporterTests/Mapping/CourseLoaderTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/Mapping/CourseLoaderTests.cs
@@ -186,7 +186,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
 
             var res = GetCourseLoader(providers).LoadCourses(provider, new List<UcasCourse> { loc1, loc2 }, new List<UcasCourseSubject>(), sites).Single();
 
-            res.AccreditingProvider.ProviderCode.Should().Be("RIGHT_ACC");
+            res.AccreditingProviderCode.Should().Be("RIGHT_ACC");
             res.Provider.ProviderCode.Should().Be("RIGHT_INST");
         }
 
@@ -200,7 +200,7 @@ namespace GovUk.Education.ManageCourses.UcasCourseImporter.Tests
 
             var res = LoadCourse(loc1);
 
-            res.AccreditingProvider.ProviderCode.Should().Be("RIGHT_ACC");
+            res.AccreditingProviderCode.Should().Be("RIGHT_ACC");
             res.Provider.ProviderCode.Should().Be("RIGHT_INST");
         }
 

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorAllVariationTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorAllVariationTests.cs
@@ -68,10 +68,10 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
                         .WithName(unmodifiedCourseName),
                     new CourseBuilder()
                         .WithCode(courseCode2)
-                        .WithAccreditingProvider(accreditingProvider),
+                        .WithAccreditingProviderCode(accreditingProviderCode),
                     new CourseBuilder()
                         .WithCode(courseCode3)
-                        .WithAccreditingProvider(accreditingProviderOptedIn),
+                        .WithAccreditingProviderCode(accreditingProviderCodeOptedIn),
                 }));
             // opted in provider and its courses
             Context.Providers.Add(new ProviderBuilder()
@@ -85,10 +85,10 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
                         .WithName(unmodifiedCourseName),
                     new CourseBuilder()
                         .WithCode(courseCode2)
-                        .WithAccreditingProvider(accreditingProvider),
+                        .WithAccreditingProviderCode(accreditingProviderCode),
                     new CourseBuilder()
                         .WithCode(courseCode3)
-                        .WithAccreditingProvider(accreditingProviderOptedIn),
+                        .WithAccreditingProviderCode(accreditingProviderCodeOptedIn),
                 }));
             Context.Save();
 
@@ -152,9 +152,9 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
             provider.Courses.Single(c => c.Provider.ProviderCode == instCode && c.CourseCode == courseCode)
                 .Name.Should().Be(modifiedCourseName);
             provider.Courses.Single(c => c.Provider.ProviderCode == instCode && c.CourseCode == courseCode2)
-                .AccreditingProvider.ProviderCode.Should().Be(accreditingProviderCode3);
+                .AccreditingProviderCode.Should().Be(accreditingProviderCode3);
             provider.Courses.Single(c => c.Provider.ProviderCode == instCode && c.CourseCode == courseCode3)
-                .AccreditingProvider.ProviderCode.Should().Be(accreditingProviderCode4);
+                .AccreditingProviderCode.Should().Be(accreditingProviderCode4);
         }
 
         private void DoImport(UcasPayload ucasPayload)

--- a/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorOptInTests.cs
+++ b/tests/ManageCourses.Tests/ImporterTests/UcasDataMigratorOptInTests.cs
@@ -132,7 +132,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
             var provider = Context.Providers.Single(p => p.ProviderCode == instCode);
             provider.Courses.Count.Should().Be(1);
             provider.Courses.Single(c => c.CourseCode == courseCode)
-                .AccreditingProvider.ProviderCode.Should().Be(accreditingProviderCode);
+                .AccreditingProviderCode.Should().Be(accreditingProviderCode);
 
             // import as modified
             ucasCourse.AccreditingProvider = accreditingProviderCode2;
@@ -140,7 +140,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
             var updatedProvider = Context.Providers.Single(p => p.ProviderCode == instCode);
             updatedProvider.Courses.Count.Should().Be(1);
             updatedProvider.Courses.Single(c => c.CourseCode == courseCode)
-                .AccreditingProvider.ProviderCode.Should().Be(accreditingProviderCode2);
+                .AccreditingProviderCode.Should().Be(accreditingProviderCode2);
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
             var provider = Context.Providers.Single(p => p.ProviderCode == instCode);
             provider.Courses.Count.Should().Be(1);
             provider.Courses.Single(c => c.CourseCode == courseCode)
-                .AccreditingProvider.ProviderCode.Should().Be(accreditingProviderCode);
+                .AccreditingProviderCode.Should().Be(accreditingProviderCode);
 
             // import as modified
             ucasCourse.AccreditingProvider = accreditingProviderCode2;
@@ -193,7 +193,7 @@ namespace GovUk.Education.ManageCourses.Tests.ImporterTests
             var updatedProvider = Context.Providers.Single(p => p.ProviderCode == instCode);
             updatedProvider.Courses.Count.Should().Be(1);
             updatedProvider.Courses.Single(c => c.CourseCode == courseCode)
-                .AccreditingProvider.ProviderCode.Should().Be(accreditingProviderCode2);
+                .AccreditingProviderCode.Should().Be(accreditingProviderCode2);
         }
 
         private void DoImport(UcasPayload ucasPayload)

--- a/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/CourseMapperTests.cs
@@ -15,7 +15,15 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
     [TestFixture]
     public class CourseMapperTests
     {
-        private ICourseMapper mapper = new CourseMapper();
+        private const string AccreditingProviderCode = "ACC123";
+        private const string AccreditingProviderName = "AccreditingProviderName";
+
+        private ICourseMapper mapper = new CourseMapper(GetProviderNameMock);
+
+        private static string GetProviderNameMock(string providerCode)
+        {
+            return providerCode == AccreditingProviderCode ? AccreditingProviderName : null;
+        }
 
         [Test]
         public void MapToSearchAndCompareCourse_ProviderLocation()
@@ -89,8 +97,9 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
 
             res.Provider.ProviderCode.Should().Be("ABC");
             res.Provider.Name.Should().Be("My provider");
-            res.AccreditingProvider.ProviderCode.Should().Be("ACC123");
-            res.AccreditingProvider.Name.Should().Be("AccreditingProviderName");
+            res.AccreditingProvider.Should().NotBeNull();
+            res.AccreditingProvider.ProviderCode.Should().Be(AccreditingProviderCode);
+            res.AccreditingProvider.Name.Should().Be(AccreditingProviderName);
 
             res.Route.Name.Should().Be("School Direct (salaried) training programme");
             res.Route.IsSalaried.Should().Be(true);
@@ -138,8 +147,9 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
 
             res.Provider.ProviderCode.Should().Be("ABC");
             res.Provider.Name.Should().Be("My provider");
-            res.AccreditingProvider.ProviderCode.Should().Be("ACC123");
-            res.AccreditingProvider.Name.Should().Be("AccreditingProviderName");
+            res.AccreditingProvider.Should().NotBeNull();
+            res.AccreditingProvider.ProviderCode.Should().Be(AccreditingProviderCode);
+            res.AccreditingProvider.Name.Should().Be(AccreditingProviderName);
 
             res.Route.Name.Should().Be("School Direct (salaried) training programme");
             res.Route.IsSalaried.Should().Be(true);
@@ -245,7 +255,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
                     {
                         new AccreditingProviderEnrichment
                         {
-                            UcasProviderCode = "ACC123",
+                            UcasProviderCode = AccreditingProviderCode,
                             Description = "AccreditingProviderDescription"
                         }
                     }
@@ -257,7 +267,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             return new Course
             {
                 CourseCode = "CourseCode",
-                AccreditingProvider = new Provider {ProviderCode  = "ACC123", ProviderName = "AccreditingProviderName"},
+                AccreditingProviderCode = AccreditingProviderCode,
                 Qualification = CourseQualification.QtsWithPgce,
                 ProgramType = "SS", // school direct salaried
                 Name = "Course.Name",

--- a/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
@@ -40,7 +40,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             _httpMock = new Mock<IHttpClient>();
             var searchAndCompareApi = new SearchAndCompareApi(_httpMock.Object, sncUrl);
 
-            _searchAndCompareService = new SearchAndCompareService(searchAndCompareApi, new CourseMapper(), _dataServiceMock.Object, _enrichmentServiceMock.Object, _loggerMock.Object);
+            _searchAndCompareService = new SearchAndCompareService(searchAndCompareApi, new CourseMapper((x)=>null), _dataServiceMock.Object, _enrichmentServiceMock.Object, _loggerMock.Object);
         }
 
         [Test]
@@ -50,8 +50,8 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             Provider provider = new Provider
             {
                 ProviderCode = ProviderCode,
-                AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
+//                AccreditedCourses =
+//                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
             };
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))
@@ -84,8 +84,8 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             var provider = new Provider
             {
                 ProviderCode = ProviderCode,
-                AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
+//                AccreditedCourses =
+//                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
             };
 
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
@@ -128,8 +128,8 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             Provider provider = new Provider
             {
                 ProviderCode = ProviderCode,
-                AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
+//                AccreditedCourses =
+//                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
             };
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))
@@ -152,8 +152,8 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             var provider = new Provider
             {
                 ProviderCode = ProviderCode,
-                AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" }, new Course { CourseCode = CourseCode + "1", ProgramType = "SD", Name = "Geography" } }
+//                AccreditedCourses =
+//                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" }, new Course { CourseCode = CourseCode + "1", ProgramType = "SD", Name = "Geography" } }
             };
 
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
@@ -188,8 +188,8 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
             var provider = new Provider
             {
                 ProviderCode = ProviderCode,
-                AccreditedCourses =
-                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
+//                AccreditedCourses =
+//                    new List<Course> { new Course { CourseCode = CourseCode, ProgramType = "SD", Name = "History" } }
             };
             _dataServiceMock.Setup(x => x.GetProviderForUser(email, ProviderCode)).Returns(provider);
             _dataServiceMock.Setup(x => x.GetCourseForUser(email, ProviderCode, CourseCode))

--- a/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
+++ b/tests/ManageCourses.Tests/UnitTesting/SearchAndCompareServiceTests.cs
@@ -44,6 +44,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         }
 
         [Test]
+        [Ignore("SaveCourse has been reimplemented in Rails.")]
         public void PublishEnrichedCourseWithEmailHappyPathTest()
         {
             var email = "tester@example.com";
@@ -122,6 +123,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         }
 
         [Test]
+        [Ignore("SaveCourse has been reimplemented in Rails.")]
         public void PublishEnrichedCourseWithEmailDraftTest()
         {
             var email = "tester@example.com";
@@ -223,6 +225,7 @@ namespace GovUk.Education.ManageCourses.Tests.UnitTesting
         [TestCase("123", null, null)]
         [TestCase(null, "234", null)]
         [TestCase(null, null, "email@qwe.com")]
+        [Ignore("SaveCourse has been reimplemented in Rails.")]
         public void PublishCourseWithEmailInvalidParametersTest(string providerCode, string courseCode, string email)
         {
             var result = _searchAndCompareService.SaveCourse(providerCode, courseCode, email).Result;


### PR DESCRIPTION
### Context

* Model from Rails side is changing to not have accrediting_provider_id,
  this is so that we can rollover a single provider without recursing.
  New column has been added by manage-courses-backend in a migration.
    
Pairing Tim+Sau

### Changes proposed in this pull request

Keeping up with rails

### Guidance to review

:eyes: 