### PR TITLE
127 investigate release failures caused by postgreserver firewall rules

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -190,7 +190,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/127-investigate-release-failures-caused-by-postgreserver-firewall-rules/templates/",
         "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
         "resourceNamePrefix": "[toLower(concat('bat-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
@@ -703,7 +703,8 @@
                 }
             },
             "dependsOn": [
-                "postgresql-server"
+                "postgresql-server",
+                "postgresql-server-firewall-rules"
             ]
         },
         {

--- a/azure/template.json
+++ b/azure/template.json
@@ -190,7 +190,7 @@
         }
     },
     "variables": {
-        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/127-investigate-release-failures-caused-by-postgreserver-firewall-rules/templates/",
+        "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
         "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
         "resourceNamePrefix": "[toLower(concat('bat-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",


### PR DESCRIPTION
### Context
On random instances Azure DevOps release fails whilst adding firewall rules in PostgreSQL server with a conflict error message.
Both app service and worker app service attempts to add same IP address in the firewall rules list at the same time. Issue is not with the identical IP address but likely to be delay in processing the requests.

### Changes proposed in this pull request
Delay worker app's postgresql firewall rules update task to start after other firewall rules update tasks.

### Guidance to review
Serialise the tasks by using dependson function
