### PR TITLE
1960 move pgpass to portal

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,6 @@ pool:
 variables:
   buildConfiguration: 'release'
   buildPlatform: 'anycpu'
-  pgUsername: 'vsts'
-  pgPassword: 'SKsktzT1yNqCPgFD4kcI'
 
 steps:
 - script: |


### PR DESCRIPTION
### Context

These values are used to build the CI postgres server, and then connect to it.

These can be set in the Azure DevOps web interface instead which is more secure

### Changes proposed in this pull request

### Guidance to review

