### PR TITLE
Updated ARM template and removed bat from resource name prefix

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -5,7 +5,7 @@
         "resourceEnvironmentName": {
             "type": "string",
             "metadata": {
-                "description": "The environment of the resource."
+                "description": "The prefix and environment of the resource."
             }
         },
         "serviceName": {
@@ -192,7 +192,7 @@
     "variables": {
         "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
         "keyvaultCertificateName": "[if(greater(length(parameters('certificateName')),0), parameters('certificateName'), replace(parameters('customHostName'), '.', '-'))]",
-        "resourceNamePrefix": "[toLower(concat('bat-', parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
+        "resourceNamePrefix": "[toLower(concat(parameters('resourceEnvironmentName'),'-', parameters('serviceName')))]",
         "appServiceName": "[concat(variables('resourceNamePrefix'), '-as')]",
         "workerAppServiceName": "[concat(variables('resourceNamePrefix'), 'wkr-as')]",
         "appServicePlanName": "[concat(variables('resourceNamePrefix'), '-asp')]",


### PR DESCRIPTION
### Context
'BAT' prefix is hardcoded in the ARM templates as a resource name prefix for all resources which isn't inline with the new naming convention standard of CIP subscriptions .
https://docs.platform.education.gov.uk/operations/standards/naming-standards.html

### Changes proposed in this pull request
Remove 'Bat' from ARM template resource name prefixes variable and insert it in the Azure Pipeline variables 'resourceEnvironmentName'  to override.
